### PR TITLE
Retry transient ShizukuProvider lookup during UserService attach

### DIFF
--- a/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
+++ b/starter/src/main/java/moe/shizuku/starter/ServiceStarter.java
@@ -23,6 +23,8 @@ public class ServiceStarter {
 
     private static final String EXTRA_BINDER = "moe.shizuku.privileged.api.intent.extra.BINDER";
 
+    private static final long[] NULL_PROVIDER_RETRY_BACKOFF_MS = {250, 500, 1000, 1500};
+
     public static final String DEBUG_ARGS;
 
     static {
@@ -98,10 +100,19 @@ public class ServiceStarter {
         IContentProvider provider = null;
 
         try {
-            provider = ActivityManagerApis.getContentProviderExternal(name, userId, null, name);
-            if (provider == null) {
-                Log.e(TAG, String.format("provider is null %s %d", name, userId));
-                return false;
+            for (int attempt = 0; ; attempt++) {
+                provider = ActivityManagerApis.getContentProviderExternal(name, userId, null, name);
+                if (provider != null) {
+                    break;
+                }
+                if (attempt >= NULL_PROVIDER_RETRY_BACKOFF_MS.length) {
+                    Log.e(TAG, String.format("provider is null %s %d (gave up after %d attempts)", name, userId, attempt + 1));
+                    return false;
+                }
+                long backoff = NULL_PROVIDER_RETRY_BACKOFF_MS[attempt];
+                Log.w(TAG, String.format("provider is null %s %d, retrying in %dms (attempt %d/%d)",
+                        name, userId, backoff, attempt + 1, NULL_PROVIDER_RETRY_BACKOFF_MS.length + 1));
+                Thread.sleep(backoff);
             }
             if (!provider.asBinder().pingBinder()) {
                 Log.e(TAG, String.format("provider is dead %s %d", name, userId));


### PR DESCRIPTION
## Summary
This ports the app-side ServiceStarter fix for transient manager-provider lookup failures.

## What changed
- Adds a short bounded retry/backoff around `ActivityManagerApis.getContentProviderExternal` when sending the UserService binder back to the manager.
- Keeps the existing dead-provider force-stop retry path unchanged.
- Does not force-stop the manager when the provider lookup simply returns null.

## Why
On some devices the manager provider can be momentarily unpublished because the app process is cached/frozen or still starting. Previously the spawned UserService exited immediately, which made rebinds unreliable. Retrying for a few seconds lets transient manager unavailability recover without introducing a new kill/restart race.

## Testing
- `git diff --check` passed for this branch.
- This is covered by the UserService stress workflow branch as an app-side companion fix.
