### PR TITLE
Prefer fresh package-manager binder results for app lists

### DIFF
--- a/common/src/main/java/moe/shizuku/common/util/InstalledPackagesCompat.java
+++ b/common/src/main/java/moe/shizuku/common/util/InstalledPackagesCompat.java
@@ -31,15 +31,30 @@ public final class InstalledPackagesCompat {
     @SuppressWarnings("unchecked")
     public static List<PackageInfo> getInstalledPackages(long flags, int userId) throws ReflectiveOperationException {
         try {
+            List<PackageInfo> packages = getInstalledPackagesViaBinder(flags, userId);
+            if (!packages.isEmpty()) {
+                return packages;
+            }
+        } catch (NoSuchMethodException ignored) {
+        } catch (Exception e) {
+            Log.d(TAG, "getInstalledPackages via hidden IPackageManager failed, falling back to context PackageManager", e);
+        }
+
+        try {
             Object packageManager = getContextPackageManager();
             Method method = packageManager.getClass().getMethod("getInstalledPackagesAsUser", int.class, int.class);
             Object result = invoke(method, packageManager, (int) flags, userId);
             return result == null ? Collections.emptyList() : (List<PackageInfo>) result;
         } catch (NoSuchMethodException ignored) {
         } catch (Exception e) {
-            Log.d(TAG, "getInstalledPackagesAsUser failed, falling back to hidden API", e);
+            Log.d(TAG, "getInstalledPackagesAsUser fallback failed", e);
         }
 
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<PackageInfo> getInstalledPackagesViaBinder(long flags, int userId) throws ReflectiveOperationException {
         Object packageManager = getPackageManager();
         Method method;
         Object result;


### PR DESCRIPTION
## Summary
This ports the stale authorized-app count/package-list fix.

## What changed
- Prefer querying installed packages through the hidden package-manager binder path.
- Keep the context `PackageManager#getInstalledPackagesAsUser` path as a fallback.
- Return an empty list only if both approaches fail or are unavailable.

## Why
The long-lived server process can observe stale package-list snapshots through the context PackageManager path. Querying the system package-manager binder directly avoids stale app lists and fixes authorized-app counts that otherwise do not update until a service restart.

## Testing
- `git diff --check` passed for this branch.
