### PR TITLE
Sanitize wireless pairing code notification replies

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbPairingService.kt
@@ -85,12 +85,15 @@ class AdbPairingService : Service() {
                 onStart()
             }
             replyAction -> {
-                val code = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(remoteInputResultKey) ?: ""
+                val raw = (RemoteInput.getResultsFromIntent(intent)?.getCharSequence(remoteInputResultKey) ?: "")
+                    .toString()
+                val code = raw.filter { !it.isWhitespace() }
                 val port = intent.getIntExtra(portKey, -1)
-                if (port != -1) {
-                    onInput(code.toString(), port)
-                } else {
-                    onStart()
+                when {
+                    code.isEmpty() && port != -1 -> createInputNotification(port)
+                    code.isEmpty() -> onStart()
+                    port != -1 -> onInput(code, port)
+                    else -> onStart()
                 }
             }
             stopAction -> {


### PR DESCRIPTION
## Summary
This ports the pairing-code whitespace fix.

## What changed
- Converts the RemoteInput result to a string and strips all whitespace, not just leading/trailing whitespace.
- Handles empty duplicate submits by recreating the input notification instead of sending a bogus pairing attempt.
- Keeps the existing restart behavior for empty replies without a valid port.

## Why
Some IMEs append newlines, spaces, or duplicate empty submits from notification inline replies. Passing those characters into the pairing flow makes a correct six-digit code fail as incorrect. Filtering all whitespace before pairing keeps user input robust across IMEs.

## Testing
- `git diff --check` passed for this branch.
