### PR TITLE
Reconcile auto-disable USB debugging after reboot

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -180,6 +180,15 @@
         </receiver>
 
         <receiver
+            android:name=".receiver.AutoDisableUsbDebuggingReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
             android:name=".receiver.SheveryControlReceiver"
             android:enabled="true"
             android:exported="false">

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
@@ -26,6 +26,7 @@ public class ShizukuSettings {
     public static final String LANGUAGE = "language";
     public static final String KEEP_START_ON_BOOT = "start_on_boot";
     public static final String TCP_MODE = "tcp_mode";
+    public static final String AUTO_DISABLE_USB_DEBUGGING = "auto_disable_usb_debugging";
 
 
     private static SharedPreferences sPreferences;
@@ -114,6 +115,14 @@ public class ShizukuSettings {
 
     public static void setTcpMode(boolean enabled) {
         getPreferences().edit().putBoolean(TCP_MODE, enabled).apply();
+    }
+
+    public static boolean getAutoDisableUsbDebugging() {
+        return getPreferences().getBoolean(AUTO_DISABLE_USB_DEBUGGING, false);
+    }
+
+    public static void setAutoDisableUsbDebugging(boolean enabled) {
+        getPreferences().edit().putBoolean(AUTO_DISABLE_USB_DEBUGGING, enabled).apply();
     }
 
 

--- a/manager/src/main/java/moe/shizuku/manager/receiver/AutoDisableUsbDebuggingReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/AutoDisableUsbDebuggingReceiver.kt
@@ -1,0 +1,25 @@
+package moe.shizuku.manager.receiver
+
+import android.Manifest.permission.WRITE_SECURE_SETTINGS
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
+import moe.shizuku.manager.ShizukuSettings
+
+class AutoDisableUsbDebuggingReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        ShizukuSettings.initialize(context)
+        if (!ShizukuSettings.getAutoDisableUsbDebugging()) return
+
+        val bootReceiver = ComponentName(context.packageName, BootCompleteReceiver::class.java.name)
+        if (context.packageManager.isComponentEnabled(bootReceiver)) return
+        if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) return
+
+        Settings.Global.putInt(context.contentResolver, Settings.Global.ADB_ENABLED, 0)
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/receiver/AutoDisableUsbDebuggingReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/AutoDisableUsbDebuggingReceiver.kt
@@ -6,6 +6,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+import android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
 import android.provider.Settings
 import moe.shizuku.manager.ShizukuSettings
 
@@ -17,7 +19,8 @@ class AutoDisableUsbDebuggingReceiver : BroadcastReceiver() {
         if (!ShizukuSettings.getAutoDisableUsbDebugging()) return
 
         val bootReceiver = ComponentName(context.packageName, BootCompleteReceiver::class.java.name)
-        if (context.packageManager.isComponentEnabled(bootReceiver)) return
+        val bootReceiverState = context.packageManager.getComponentEnabledSetting(bootReceiver)
+        if (bootReceiverState == COMPONENT_ENABLED_STATE_ENABLED || bootReceiverState == COMPONENT_ENABLED_STATE_DEFAULT) return
         if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) return
 
         Settings.Global.putInt(context.contentResolver, Settings.Global.ADB_ENABLED, 0)

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -82,6 +82,9 @@ fun SettingsScreen() {
     var tcpMode by remember {
         mutableStateOf(ShizukuSettings.isTcpMode())
     }
+    var autoDisableUsbDebugging by remember {
+        mutableStateOf(ShizukuSettings.getAutoDisableUsbDebugging())
+    }
     var languageTag by remember {
         mutableStateOf(prefs.getString(LANGUAGE, "SYSTEM") ?: "SYSTEM")
     }
@@ -235,6 +238,16 @@ fun SettingsScreen() {
                     onCheckedChange = { enabled ->
                         ShizukuSettings.setTcpMode(enabled)
                         tcpMode = ShizukuSettings.isTcpMode()
+                    }
+                )
+                SwitchSettingsRow(
+                    icon = R.drawable.ic_adb_24dp,
+                    title = stringResource(R.string.settings_auto_disable_usb_debugging),
+                    summary = stringResource(R.string.settings_auto_disable_usb_debugging_summary),
+                    checked = autoDisableUsbDebugging,
+                    onCheckedChange = { enabled ->
+                        ShizukuSettings.setAutoDisableUsbDebugging(enabled)
+                        autoDisableUsbDebugging = ShizukuSettings.getAutoDisableUsbDebugging()
                     }
                 )
             }

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -284,6 +284,8 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="dhizuku_warning_message">Dhizuku is designed for Device Owner/admin privileges. Some shell and ADB-specific commands may not work properly or may be entirely unsupported when running Shevery via Dhizuku. Are you sure you want to proceed?</string>
     <string name="settings_tcp_mode">TCP Mode</string>
     <string name="settings_tcp_mode_summary">Attempt to reconnect and restart server via local ADB on port 5555 (watchdog)</string>
+    <string name="settings_auto_disable_usb_debugging">Auto-disable USB debugging</string>
+    <string name="settings_auto_disable_usb_debugging_summary">Turn off USB debugging after reboot when Shevery is not configured to start on boot</string>
     <string name="settings_service_group">Service Maintenance</string>
 
     <!-- Lab Features - Service Behavior -->


### PR DESCRIPTION
## Summary
This ports the auto-disable USB debugging reboot reconciliation fix into Shevery.

## What changed
- Adds a user-facing "Auto-disable USB debugging" setting under Service Maintenance.
- Adds persisted settings accessors for the new option.
- Registers an always-enabled boot receiver dedicated to reconciling this setting after reboot.
- On boot, if the setting is enabled, Shevery is not configured to start on boot, and the app has `WRITE_SECURE_SETTINGS`, USB debugging is turned off.

## Why
A reboot kills the app/server without an orderly stop path, so any stop-time USB-debugging cleanup does not run. This receiver reconciles the user preference after boot while avoiding the start-on-boot case where ADB may still be needed.

## Testing
- `git diff --check` passed for this branch.
- Runtime behavior requires Android boot/emulator validation with `WRITE_SECURE_SETTINGS` granted.
