### PR TITLE
Fortify Shevery watchdog keep-alive

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"
+        tools:targetApi="34" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
@@ -165,6 +168,16 @@
             android:enabled="true"
             android:exported="true"
             android:permission="moe.shizuku.manager.permission.API_V23" />
+
+        <service
+            android:name=".service.WatchdogService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Keeps Shevery service watchdog monitoring active while keep-alive or auto-restart is enabled." />
+        </service>
 
         <receiver
             android:name=".receiver.BootCompleteReceiver"

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -40,6 +40,7 @@ class ShizukuApplication : Application() {
         application = this
         init(this)
         moe.shizuku.manager.service.WatchdogManager.init(this)
+        moe.shizuku.manager.service.WatchdogManager.reconcileService(this)
         moe.shizuku.manager.service.SheveryNotificationManager.setup(this)
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -6,50 +6,84 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
 import moe.shizuku.manager.adb.AdbClient
 import moe.shizuku.manager.adb.AdbKey
+import moe.shizuku.manager.adb.AdbMdns
 import moe.shizuku.manager.adb.PreferenceAdbKeyStore
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.ktx.logi
 import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.manager.starter.Starter
+import moe.shizuku.manager.utils.EnvironmentUtils
 import rikka.shizuku.Shizuku
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 object WatchdogManager {
 
-    @Volatile
-    var expectingDeath = false
-
     private const val CHANNEL_ID = "service_watchdog"
     private const val NOTIFICATION_ID = 1001
+    private const val EXPECTED_DEATH_WINDOW_MS = 10_000L
+    private const val WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS = 5L
+    private const val DHIZUKU_BIND_TIMEOUT_MS = 10_000L
+
+    @Volatile
+    var expectingDeath = false
+        set(value) {
+            field = value
+            expectedDeathDeadlineMillis = if (value) {
+                SystemClock.elapsedRealtime() + EXPECTED_DEATH_WINDOW_MS
+            } else {
+                0L
+            }
+        }
+
+    @Volatile
+    private var expectedDeathDeadlineMillis = 0L
+
+    @Volatile
     private var initialized = false
 
+    private val restartInProgress = AtomicBoolean(false)
+
     fun init(context: Context) {
+        val appContext = context.applicationContext
         if (initialized) return
         initialized = true
 
         logi("Initializing service watchdog")
 
         Shizuku.addBinderDeadListener {
-            onServiceDied(context)
+            onServiceDied(appContext)
         }
+    }
+
+    fun isEnabled(): Boolean {
+        return ModuleSettings.isAutoRestartOnCrash() || ModuleSettings.isKeepAlive()
+    }
+
+    fun reconcileService(context: Context) {
+        WatchdogService.reconcile(context.applicationContext)
     }
 
     private fun onServiceDied(context: Context) {
         logd("Service died detected by watchdog")
 
-        if (expectingDeath) {
+        if (consumeExpectedDeath()) {
             logi("Service death was expected (user stopped it). Resetting flag.")
-            expectingDeath = false
             return
         }
 
@@ -57,8 +91,32 @@ object WatchdogManager {
             showDeathNotification(context)
         }
 
-        if (ModuleSettings.isAutoRestartOnCrash() || ModuleSettings.isKeepAlive()) {
+        if (isEnabled()) {
             attemptRestart(context)
+        }
+    }
+
+    private fun consumeExpectedDeath(): Boolean {
+        if (!expectingDeath) return false
+
+        val now = SystemClock.elapsedRealtime()
+        val deadline = expectedDeathDeadlineMillis
+        expectingDeath = false
+
+        if (deadline == 0L || now <= deadline) {
+            return true
+        }
+
+        logd("Ignoring stale expected-death flag")
+        return false
+    }
+
+    private fun clearExpectedDeathWhenStale() {
+        if (!expectingDeath) return
+        val deadline = expectedDeathDeadlineMillis
+        if (deadline != 0L && SystemClock.elapsedRealtime() > deadline) {
+            logd("Clearing stale expected-death flag")
+            expectingDeath = false
         }
     }
 
@@ -93,139 +151,174 @@ object WatchdogManager {
     }
 
     fun attemptRestart(context: Context) {
-        val lastMode = ShizukuSettings.getLastLaunchMode()
-        logi("Attempting to restart service (Last mode: $lastMode)")
+        val appContext = context.applicationContext
+        clearExpectedDeathWhenStale()
 
-        when (lastMode) {
-            LaunchMethod.ROOT -> {
-                CoroutineScope(Dispatchers.IO).launch {
-                    if (!Shell.getShell().isRoot) {
-                        Shell.getCachedShell()?.close()
-                    }
-                    if (Shell.getShell().isRoot) {
-                        Shell.cmd(Starter.internalCommand).exec()
-                    }
+        if (!restartInProgress.compareAndSet(false, true)) {
+            logd("Restart already in progress, skipping duplicate watchdog restart")
+            return
+        }
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val lastMode = ShizukuSettings.getLastLaunchMode()
+                logi("Attempting to restart service (Last mode: $lastMode)")
+
+                when (lastMode) {
+                    LaunchMethod.ROOT -> restartRoot()
+                    LaunchMethod.ADB -> restartAdb(appContext)
+                    LaunchMethod.DHIZUKU -> restartDhizuku(appContext)
                 }
-            }
-            LaunchMethod.ADB -> {
-                // If TCP mode was enabled, we can try localhost:5555
-                if (ShizukuSettings.isTcpMode()) {
-                    restartTcp(context)
-                }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    restartWirelessAdb(context)
-                }
-            }
-            LaunchMethod.DHIZUKU -> {
-                restartDhizuku(context)
+            } finally {
+                restartInProgress.set(false)
             }
         }
     }
 
     fun stopServer() {
+        expectingDeath = true
         try {
-            expectingDeath = true
             Shizuku.exit()
-        } catch (_: Throwable) {}
-    }
-
-    private fun restartTcp(context: Context) {
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val host = "127.0.0.1"
-                val port = 5555
-                val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
-                val client = AdbClient(host, port, key)
-                client.connect()
-                client.shellCommand(Starter.internalCommand) { _ -> }
-                client.close()
-                logi("Restart via TCP sent")
-            } catch (e: Exception) {
-                logd("Restart via TCP failed: ${e.message}")
-            }
+        } catch (_: Throwable) {
+            expectingDeath = false
         }
     }
 
-    private fun restartWirelessAdb(context: Context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
-        CoroutineScope(Dispatchers.IO).launch {
-            val latch = java.util.concurrent.CountDownLatch(1)
-            val adbMdns = moe.shizuku.manager.adb.AdbMdns(context, moe.shizuku.manager.adb.AdbMdns.TLS_CONNECT) { port ->
-                if (port <= 0) return@AdbMdns
-                try {
-                    val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
-                    val key = AdbKey(keystore, "shizuku")
-                    val client = AdbClient("127.0.0.1", port, key)
+    private fun restartRoot() {
+        try {
+            if (!Shell.getShell().isRoot) {
+                Shell.getCachedShell()?.close()
+            }
+            if (Shell.getShell().isRoot) {
+                Shell.cmd(Starter.internalCommand).exec()
+            }
+        } catch (e: Exception) {
+            logd("Watchdog root restart failed: ${e.message}")
+        }
+    }
+
+    private fun restartAdb(context: Context) {
+        if (ShizukuSettings.isTcpMode() && restartTcp(context)) {
+            return
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            restartWirelessAdb(context)
+        }
+    }
+
+    private fun restartTcp(context: Context): Boolean {
+        val livePort = EnvironmentUtils.getLiveAdbTcpPort()
+        val configuredPort = EnvironmentUtils.getAdbTcpPort()
+        val candidatePorts = sequenceOf(livePort, configuredPort, 5555)
+            .filter { it > 0 }
+            .distinct()
+            .toList()
+
+        if (candidatePorts.isEmpty()) {
+            logd("Restart via TCP skipped: no candidate ADB TCP ports")
+            return false
+        }
+
+        val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
+        for (port in candidatePorts) {
+            try {
+                AdbClient("127.0.0.1", port, key).use { client ->
                     client.connect()
                     client.shellCommand(Starter.internalCommand) { _ -> }
-                    client.close()
-                    logi("Restart via Wireless ADB successful on port $port")
-                } catch (e: Exception) {
-                    logd("Restart via Wireless ADB failed on port $port: ${e.message}")
                 }
-                latch.countDown()
+                logi("Restart via TCP sent on port $port")
+                return true
+            } catch (e: Exception) {
+                logd("Restart via TCP failed on port $port: ${e.message}")
             }
+        }
+        return false
+    }
+
+    private fun restartWirelessAdb(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return false
+
+        var restarted = false
+        val latch = CountDownLatch(1)
+        val adbMdns = AdbMdns(context, AdbMdns.TLS_CONNECT) { port ->
+            if (port <= 0 || restarted) return@AdbMdns
+            try {
+                val keystore = PreferenceAdbKeyStore(ShizukuSettings.getPreferences())
+                val key = AdbKey(keystore, "shizuku")
+                AdbClient("127.0.0.1", port, key).use { client ->
+                    client.connect()
+                    client.shellCommand(Starter.internalCommand) { _ -> }
+                }
+                restarted = true
+                logi("Restart via Wireless ADB successful on port $port")
+                latch.countDown()
+            } catch (e: Exception) {
+                logd("Restart via Wireless ADB failed on port $port: ${e.message}")
+            }
+        }
+
+        return try {
             adbMdns.start()
-            latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+            latch.await(WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            restarted
+        } finally {
             adbMdns.stop()
         }
     }
 
-    private fun restartDhizuku(context: Context) {
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                logi("Watchdog attempting Dhizuku restart...")
-                val initResult = com.rosan.dhizuku.api.Dhizuku.init(context.applicationContext)
-                if (!initResult) {
-                    logd("Dhizuku init failed in watchdog")
-                    return@launch
-                }
-                if (!com.rosan.dhizuku.api.Dhizuku.isPermissionGranted()) {
-                    logd("Dhizuku permission is not granted in watchdog")
-                    return@launch
-                }
-                val userServiceArgs = com.rosan.dhizuku.api.DhizukuUserServiceArgs(
-                    android.content.ComponentName(context.applicationContext, moe.shizuku.manager.dhizuku.DhizukuService::class.java)
-                )
-                var connection: android.content.ServiceConnection? = null
-                val serviceResult = kotlinx.coroutines.withTimeoutOrNull(10000) {
-                    kotlinx.coroutines.suspendCancellableCoroutine<android.os.IBinder?> { cont ->
-                        val conn = object : android.content.ServiceConnection {
-                            override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
-                                if (cont.isActive) cont.resumeWith(Result.success(service))
-                            }
-                            override fun onServiceDisconnected(name: android.content.ComponentName?) {}
+    private suspend fun restartDhizuku(context: Context) {
+        try {
+            logi("Watchdog attempting Dhizuku restart...")
+            val initResult = com.rosan.dhizuku.api.Dhizuku.init(context.applicationContext)
+            if (!initResult) {
+                logd("Dhizuku init failed in watchdog")
+                return
+            }
+            if (!com.rosan.dhizuku.api.Dhizuku.isPermissionGranted()) {
+                logd("Dhizuku permission is not granted in watchdog")
+                return
+            }
+            val userServiceArgs = com.rosan.dhizuku.api.DhizukuUserServiceArgs(
+                android.content.ComponentName(context.applicationContext, moe.shizuku.manager.dhizuku.DhizukuService::class.java)
+            )
+            var connection: android.content.ServiceConnection? = null
+            val serviceResult = withTimeoutOrNull(DHIZUKU_BIND_TIMEOUT_MS) {
+                suspendCancellableCoroutine<android.os.IBinder?> { cont ->
+                    val conn = object : android.content.ServiceConnection {
+                        override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
+                            if (cont.isActive) cont.resumeWith(Result.success(service))
                         }
-                        connection = conn
-                        val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
-                        if (!bound && cont.isActive) {
-                            cont.resumeWith(Result.success(null))
-                        }
-                        cont.invokeOnCancellation {
-                            try {
-                                com.rosan.dhizuku.api.Dhizuku.unbindUserService(conn)
-                            } catch (e: Exception) { }
-                        }
+                        override fun onServiceDisconnected(name: android.content.ComponentName?) {}
                     }
-                }
-                if (serviceResult == null) {
-                    logd("Dhizuku service binding failed or timed out in watchdog")
-                    return@launch
-                }
-                try {
-                    val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
-                    dhizukuService.runCommand(Starter.internalCommand)
-                    logi("Watchdog started Shevery server via Dhizuku successfully")
-                } finally {
-                    connection?.let { conn ->
+                    connection = conn
+                    val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
+                    if (!bound && cont.isActive) {
+                        cont.resumeWith(Result.success(null))
+                    }
+                    cont.invokeOnCancellation {
                         try {
                             com.rosan.dhizuku.api.Dhizuku.unbindUserService(conn)
                         } catch (e: Exception) { }
                     }
                 }
-            } catch (e: Exception) {
-                logd("Watchdog Dhizuku restart failed: ${e.message}")
             }
+            if (serviceResult == null) {
+                logd("Dhizuku service binding failed or timed out in watchdog")
+                return
+            }
+            try {
+                val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
+                dhizukuService.runCommand(Starter.internalCommand)
+                logi("Watchdog started Shevery server via Dhizuku successfully")
+            } finally {
+                connection?.let { conn ->
+                    try {
+                        com.rosan.dhizuku.api.Dhizuku.unbindUserService(conn)
+                    } catch (e: Exception) { }
+                }
+            }
+        } catch (e: Exception) {
+            logd("Watchdog Dhizuku restart failed: ${e.message}")
         }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -1,0 +1,116 @@
+package moe.shizuku.manager.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import moe.shizuku.manager.MainActivity
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ktx.logd
+
+class WatchdogService : Service() {
+
+    override fun onCreate() {
+        super.onCreate()
+        WatchdogManager.init(applicationContext)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!WatchdogManager.isEnabled()) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        startAsForeground()
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun startAsForeground() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(
+                NOTIFICATION_ID,
+                buildNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, buildNotification())
+        }
+    }
+
+    private fun buildNotification(): Notification {
+        val notificationManager = getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    getString(R.string.notification_channel_watchdog),
+                    NotificationManager.IMPORTANCE_LOW
+                )
+            )
+        }
+
+        val launchIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        }
+        val launchPendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_server_ok_24dp)
+            .setContentTitle(getString(R.string.watchdog_service_title))
+            .setContentText(getString(R.string.watchdog_service_text))
+            .setContentIntent(launchPendingIntent)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "service_watchdog"
+        private const val NOTIFICATION_ID = 1002
+
+        fun reconcile(context: Context) {
+            val appContext = context.applicationContext
+            if (WatchdogManager.isEnabled()) {
+                start(appContext)
+            } else {
+                stop(appContext)
+            }
+        }
+
+        private fun start(context: Context) {
+            try {
+                val intent = Intent(context, WatchdogService::class.java)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                logd("Failed to start watchdog service: ${e.message}")
+            }
+        }
+
+        private fun stop(context: Context) {
+            try {
+                context.stopService(Intent(context, WatchdogService::class.java))
+            } catch (e: Exception) {
+                logd("Failed to stop watchdog service: ${e.message}")
+            }
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import moe.shizuku.manager.R
 import moe.shizuku.manager.app.AppActivity
 import moe.shizuku.manager.module.ModuleSettings
+import moe.shizuku.manager.service.WatchdogManager
 import moe.shizuku.manager.ui.compose.GroupDivider
 import moe.shizuku.manager.ui.compose.SettingsGroup
 import moe.shizuku.manager.ui.compose.ShizukuExpressiveTheme
@@ -82,6 +83,7 @@ class LabFeaturesActivity : AppActivity() {
                                 onCheckedChange = { value ->
                                     keepAlive = value
                                     ModuleSettings.setKeepAlive(value)
+                                    WatchdogManager.reconcileService(this@LabFeaturesActivity)
                                 }
                             )
                             GroupDivider()
@@ -93,6 +95,7 @@ class LabFeaturesActivity : AppActivity() {
                                 onCheckedChange = { value ->
                                     autoRestart = value
                                     ModuleSettings.setAutoRestartOnCrash(value)
+                                    WatchdogManager.reconcileService(this@LabFeaturesActivity)
                                 }
                             )
                             GroupDivider()

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.SystemProperties
 import java.io.File
+import java.net.InetSocketAddress
+import java.net.Socket
 
 object EnvironmentUtils {
 
@@ -28,5 +30,25 @@ object EnvironmentUtils {
         var port = SystemProperties.getInt("service.adb.tcp.port", -1)
         if (port == -1) port = SystemProperties.getInt("persist.adb.tcp.port", -1)
         return port
+    }
+
+    fun getLiveAdbTcpPort(): Int {
+        val configuredPort = getAdbTcpPort()
+        val candidates = sequenceOf(configuredPort, 5555)
+            .filter { it > 0 }
+            .distinct()
+
+        return candidates.firstOrNull { isAdbPortLive(it) } ?: -1
+    }
+
+    fun isAdbPortLive(port: Int): Boolean {
+        return try {
+            Socket().use { socket ->
+                socket.connect(InetSocketAddress("127.0.0.1", port), 250)
+            }
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 }

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -302,6 +302,8 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="notification_channel_watchdog">Service Watchdog</string>
     <string name="notification_watchdog_title">Shevery Service Stopped</string>
     <string name="notification_watchdog_text">The Shevery service has stopped unexpectedly.</string>
+    <string name="watchdog_service_title">Shevery watchdog is active</string>
+    <string name="watchdog_service_text">Monitoring the Shevery service for keep-alive recovery</string>
 
     <!-- Shevery Control Notification -->
     <string name="notification_control_channel_name">Shevery Control</string>


### PR DESCRIPTION
## Summary

This PR strengthens Shevery's existing watchdog instead of replacing it.

The existing `WatchdogManager` remains the central restart brain for root, ADB/TCP, Wireless ADB, and Dhizuku. This change adds a persistent foreground `WatchdogService` that is tied to the existing Keep Service Alive / Auto-Restart settings so the watchdog can keep monitoring even after the manager UI process would otherwise be killed.

## What changed

- Added a foreground `WatchdogService` for the existing keep-alive / auto-restart behavior.
- Starts or stops the watchdog service when the Lab keep-alive or auto-restart toggles change.
- Reconciles watchdog service state during app startup.
- Keeps the existing Binder death listener and restart paths in `WatchdogManager`.
- Adds a restart-in-progress guard so duplicate Binder-death events do not launch overlapping restart attempts.
- Makes intentional-stop handling safer by time-bounding the expected-death flag and clearing it if `Shizuku.exit()` fails.
- Improves ADB/TCP restart by trying a live TCP port first, then the configured port, then the legacy 5555 fallback.
- Keeps Wireless ADB and Dhizuku restart paths but runs them under the shared restart guard.

## Why

Shevery already had richer restart paths than the original watchdog, but the watchdog only lived inside the manager process. That meant keep-alive could fail if Android killed the manager process before the Shizuku/Shevery service died.

This PR makes keep-alive a unified, fortified watchdog mode by preserving Shevery's existing restart logic and adding a persistent foreground service wrapper around it.

## Testing

- Built the debug manager APK with `ANDROID_HOME=/usr/lib/android-sdk bash ./gradlew :manager:assembleDebug --no-daemon`.
