### PR TITLE
Clarify start on boot requirements

### DIFF
--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -126,8 +126,8 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="settings_translation_contributors">Translation contributors</string>
     <string name="settings_translation">Participate in translation</string>
     <string name="settings_translation_summary">Help us translate %s into your language</string>
-    <string name="settings_start_on_boot">Start on boot (root)</string>
-    <string name="settings_start_on_boot_summary">For rooted devices, Shevery is able to start automatically on boot</string>
+    <string name="settings_start_on_boot">Start on boot</string>
+    <string name="settings_start_on_boot_summary">Shevery can start automatically on boot after it has been started successfully.</string>
     <string name="settings_use_system_color">Use system theme color</string>
 
     <!-- ADB modules -->


### PR DESCRIPTION
## Summary
- Update the Start on boot setting title so it no longer says root is required.
- Update the summary to explain that Shevery can start automatically on boot after it has been started successfully.
- Rebase the branch onto current `main` so it contains only the intended string changes.

## Why
The boot receiver is not root-only: it supports root startup, and it also supports ADB startup on supported Android versions when `WRITE_SECURE_SETTINGS` is available. The manager service grants `WRITE_SECURE_SETTINGS` to the manager, so the previous wording made startup sound more restrictive than the implementation is.

## Testing
- `git diff --check`
- Merge compatibility checked with PRs #38 and #47.