### PR TITLE
Restore TCP Mode setting and diagnose 5555 binding

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="33" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+    <uses-permission android:name="android.permission.USE_LOOPBACK_INTERFACE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"

--- a/manager/src/main/aidl/moe/shizuku/manager/dhizuku/IDhizukuService.aidl
+++ b/manager/src/main/aidl/moe/shizuku/manager/dhizuku/IDhizukuService.aidl
@@ -4,5 +4,5 @@ interface IDhizukuService {
     void runCommand(String command);
     boolean enableAdb();
     int getAdbPort();
-    void bindAdbTcp(int port);
+    boolean bindAdbTcp(int port);
 }

--- a/manager/src/main/java/moe/shizuku/manager/dhizuku/DhizukuService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/dhizuku/DhizukuService.kt
@@ -6,6 +6,8 @@ import android.os.Build
 import android.os.SystemProperties
 import android.provider.Settings
 import android.util.Log
+import java.net.InetSocketAddress
+import java.net.Socket
 
 class DhizukuService(private val context: Context) : IDhizukuService.Stub() {
 
@@ -116,27 +118,58 @@ class DhizukuService(private val context: Context) : IDhizukuService.Stub() {
         }
     }
 
-    override fun bindAdbTcp(port: Int) {
-        try {
+    override fun bindAdbTcp(port: Int): Boolean {
+        return try {
             val targetPort = if (port > 0) port else 5555
             Log.d(TAG, "Binding ADB TCP on port $targetPort")
-            // Use shell to set the property and restart ADB daemon
-            val cmd = "setprop service.adb.tcp.port $targetPort && stop adbd && start adbd"
-            val process = Runtime.getRuntime().exec(arrayOf("sh", "-c", cmd))
-            val stdoutThread = Thread {
-                try { process.inputStream.use { it.readBytes() } } catch (_: Exception) {}
-            }
-            val stderrThread = Thread {
-                try { process.errorStream.use { it.readBytes() } } catch (_: Exception) {}
-            }
-            stdoutThread.start()
-            stderrThread.start()
-            process.waitFor()
-            stdoutThread.join(2000)
-            stderrThread.join(2000)
-            Log.d(TAG, "ADB TCP bind command finished, exit code: ${process.exitValue()}")
+            val exitCode = runAdbTcpBindCommand(targetPort)
+            val live = waitForAdbTcpPort(targetPort)
+            Log.d(TAG, "ADB TCP bind command finished, exit code: $exitCode, live: $live")
+            exitCode == 0 && live
         } catch (e: Exception) {
             Log.e(TAG, "bindAdbTcp failed", e)
+            false
+        }
+    }
+
+    private fun runAdbTcpBindCommand(port: Int): Int {
+        val cmd = "setprop service.adb.tcp.port $port; setprop ctl.restart adbd || (stop adbd; start adbd)"
+        val process = Runtime.getRuntime().exec(arrayOf("sh", "-c", cmd))
+        val stdoutThread = Thread {
+            try { process.inputStream.use { it.readBytes() } } catch (_: Exception) {}
+        }
+        val stderrThread = Thread {
+            try { process.errorStream.use { it.readBytes() } } catch (_: Exception) {}
+        }
+        stdoutThread.start()
+        stderrThread.start()
+        val exitCode = process.waitFor()
+        stdoutThread.join(2000)
+        stderrThread.join(2000)
+        return exitCode
+    }
+
+    private fun waitForAdbTcpPort(port: Int): Boolean {
+        repeat(10) {
+            if (isAdbPortLive(port)) return true
+            try {
+                Thread.sleep(500)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return false
+            }
+        }
+        return false
+    }
+
+    private fun isAdbPortLive(port: Int): Boolean {
+        return try {
+            Socket().use { socket ->
+                socket.connect(InetSocketAddress("127.0.0.1", port), 250)
+            }
+            true
+        } catch (_: Exception) {
+            false
         }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -133,12 +133,12 @@ abstract class HomeActivity : AppActivity() {
     private var pendingLocalNetworkAction: (() -> Unit)? = null
 
     private val localNetworkPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { granted ->
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) {
         permissionRefreshTick.intValue++
         val action = pendingLocalNetworkAction
         pendingLocalNetworkAction = null
-        if (granted) {
+        if (buildLocalNetworkPermissionState().granted) {
             action?.invoke()
         } else {
             Toast.makeText(this, R.string.home_local_network_permission_denied, Toast.LENGTH_LONG).show()
@@ -263,7 +263,7 @@ abstract class HomeActivity : AppActivity() {
                                     },
                                     onStartDhizuku = { startDhizukuMode() },
                                     dhizukuEnabled = ModuleSettings.isDhizukuEnabled(),
-                                    onStartTcp5555 = ::bindTcp5555
+                                    onStartTcp5555 = { runWithLocalNetworkAccess(::bindTcp5555) }
                                 )
                                 1 -> moe.shizuku.manager.module.ModulesScreen(onOpenWebUi = {
                                     startActivity(
@@ -405,7 +405,7 @@ abstract class HomeActivity : AppActivity() {
         }
 
         pendingLocalNetworkAction = action
-        localNetworkPermissionLauncher.launch(state.permission!!)
+        localNetworkPermissionLauncher.launch(state.missingPermissions.toTypedArray())
     }
 
     private fun requestLocalNetworkPermission(onGranted: () -> Unit) {
@@ -416,21 +416,28 @@ abstract class HomeActivity : AppActivity() {
         }
 
         pendingLocalNetworkAction = onGranted
-        localNetworkPermissionLauncher.launch(state.permission!!)
+        localNetworkPermissionLauncher.launch(state.missingPermissions.toTypedArray())
     }
 
     private fun buildLocalNetworkPermissionState(): LocalNetworkPermissionState {
-        val permission = when {
-            Build.VERSION.SDK_INT >= SDK_ANDROID_17 -> PERMISSION_ACCESS_LOCAL_NETWORK
-            Build.VERSION.SDK_INT >= SDK_ANDROID_13 -> Manifest.permission.NEARBY_WIFI_DEVICES
-            else -> null
+        val permissions = buildList {
+            if (Build.VERSION.SDK_INT >= SDK_ANDROID_17) {
+                add(PERMISSION_ACCESS_LOCAL_NETWORK)
+                if (isPermissionDefined(PERMISSION_USE_LOOPBACK_INTERFACE)) {
+                    add(PERMISSION_USE_LOOPBACK_INTERFACE)
+                }
+            }
+            if (Build.VERSION.SDK_INT >= SDK_ANDROID_13) {
+                add(Manifest.permission.NEARBY_WIFI_DEVICES)
+            }
+        }
+        val missingPermissions = permissions.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
         }
 
         return LocalNetworkPermissionState(
-            permission = permission,
-            required = permission != null,
-            granted = permission == null ||
-                    ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+            permissions = permissions,
+            missingPermissions = missingPermissions
         )
     }
 
@@ -477,8 +484,7 @@ abstract class HomeActivity : AppActivity() {
                         }
                         if (serviceResult != null) {
                             val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
-                            dhizukuService.bindAdbTcp(5555)
-                            success = true
+                            success = dhizukuService.bindAdbTcp(5555) && waitForAdbTcpPort(5555)
                             connection?.let {
                                 try { com.rosan.dhizuku.api.Dhizuku.unbindUserService(it) } catch (_: Exception) {}
                             }
@@ -492,10 +498,8 @@ abstract class HomeActivity : AppActivity() {
             // 2. Try via Root if not success
             if (!success && EnvironmentUtils.isRooted()) {
                 try {
-                    val result = com.topjohnwu.superuser.Shell.cmd("setprop service.adb.tcp.port 5555 && stop adbd && start adbd").exec()
-                    if (result.isSuccess) {
-                        success = true
-                    }
+                    val result = com.topjohnwu.superuser.Shell.cmd(ADB_TCP_BIND_COMMAND).exec()
+                    success = result.isSuccess && waitForAdbTcpPort(5555)
                 } catch (e: Exception) {
                     android.util.Log.d("Shevery", "Failed to bind TCP via Root: ${e.message}")
                 }
@@ -507,9 +511,9 @@ abstract class HomeActivity : AppActivity() {
                     val binder = Shizuku.getBinder()
                     if (binder != null) {
                         val service = moe.shizuku.server.IShizukuService.Stub.asInterface(binder)
-                        val process = service.newProcess(arrayOf("sh", "-c", "setprop service.adb.tcp.port 5555 && stop adbd && start adbd"), null, null)
-                        process.waitFor()
-                        success = true
+                        val process = service.newProcess(arrayOf("sh", "-c", ADB_TCP_BIND_COMMAND), null, null)
+                        val exitCode = process.waitFor()
+                        success = exitCode == 0 && waitForAdbTcpPort(5555)
                     }
                 } catch (e: Exception) {
                     android.util.Log.d("Shevery", "Failed to bind TCP via Shizuku: ${e.message}")
@@ -527,21 +531,44 @@ abstract class HomeActivity : AppActivity() {
     }
 
 
+    private fun isPermissionDefined(permission: String): Boolean {
+        return try {
+            packageManager.getPermissionInfo(permission, 0)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private suspend fun waitForAdbTcpPort(port: Int): Boolean {
+        repeat(10) {
+            if (EnvironmentUtils.isAdbPortLive(port)) return true
+            delay(500)
+        }
+        return false
+    }
+
     companion object {
+        private const val ADB_TCP_BIND_COMMAND = "setprop service.adb.tcp.port 5555; setprop ctl.restart adbd || (stop adbd; start adbd)"
         private const val SDK_ANDROID_13 = 33
-        private const val SDK_ANDROID_16 = 36
         private const val SDK_ANDROID_17 = 37
         private const val PERMISSION_ACCESS_LOCAL_NETWORK = "android.permission.ACCESS_LOCAL_NETWORK"
+        private const val PERMISSION_USE_LOOPBACK_INTERFACE = "android.permission.USE_LOOPBACK_INTERFACE"
     }
 }
 
 private data class LocalNetworkPermissionState(
-    val permission: String?,
-    val required: Boolean,
-    val granted: Boolean
+    val permissions: List<String>,
+    val missingPermissions: List<String>
 ) {
+    val required: Boolean
+        get() = permissions.isNotEmpty()
+    val granted: Boolean
+        get() = missingPermissions.isEmpty()
     val label: String
-        get() = permission?.substringAfterLast('.') ?: "none"
+        get() = permissions.takeIf { it.isNotEmpty() }
+            ?.joinToString { it.substringAfterLast('.') }
+            ?: "none"
 }
 
 private data class HomeButtonSpec(

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -458,6 +458,14 @@ abstract class HomeActivity : AppActivity() {
     private fun bindTcp5555() {
         lifecycleScope.launch(Dispatchers.IO) {
             var success = false
+            var failureReason = getString(R.string.settings_tcp_5555_bind_failed_generic)
+
+            fun recordBindFailure(route: String, reason: String, throwable: Throwable? = null) {
+                val message = "$route: $reason"
+                failureReason = message
+                android.util.Log.d("Shevery", "Failed to bind TCP 5555 via $message", throwable)
+            }
+
             // 1. Try via Dhizuku if enabled
             if (ModuleSettings.isDhizukuEnabled()) {
                 try {
@@ -485,13 +493,22 @@ abstract class HomeActivity : AppActivity() {
                         if (serviceResult != null) {
                             val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
                             success = dhizukuService.bindAdbTcp(5555) && waitForAdbTcpPort(5555)
+                            if (!success) {
+                                recordBindFailure("Dhizuku", "command finished but port 5555 did not become live")
+                            }
                             connection?.let {
                                 try { com.rosan.dhizuku.api.Dhizuku.unbindUserService(it) } catch (_: Exception) {}
                             }
+                        } else {
+                            recordBindFailure("Dhizuku", "service binding failed or timed out")
                         }
+                    } else if (!initResult) {
+                        recordBindFailure("Dhizuku", "initialization failed")
+                    } else {
+                        recordBindFailure("Dhizuku", "permission is not granted")
                     }
                 } catch (e: Exception) {
-                    android.util.Log.d("Shevery", "Failed to bind TCP via Dhizuku: ${e.message}")
+                    recordBindFailure("Dhizuku", e.message ?: e.javaClass.simpleName, e)
                 }
             }
 
@@ -500,9 +517,17 @@ abstract class HomeActivity : AppActivity() {
                 try {
                     val result = com.topjohnwu.superuser.Shell.cmd(ADB_TCP_BIND_COMMAND).exec()
                     success = result.isSuccess && waitForAdbTcpPort(5555)
+                    if (!success) {
+                        recordBindFailure(
+                            "root",
+                            "command exit code ${result.code}, port 5555 live: ${EnvironmentUtils.isAdbPortLive(5555)}"
+                        )
+                    }
                 } catch (e: Exception) {
-                    android.util.Log.d("Shevery", "Failed to bind TCP via Root: ${e.message}")
+                    recordBindFailure("root", e.message ?: e.javaClass.simpleName, e)
                 }
+            } else if (!success) {
+                recordBindFailure("root", "root shell is unavailable")
             }
 
             // 3. Try via Shizuku shell if running
@@ -514,17 +539,31 @@ abstract class HomeActivity : AppActivity() {
                         val process = service.newProcess(arrayOf("sh", "-c", ADB_TCP_BIND_COMMAND), null, null)
                         val exitCode = process.waitFor()
                         success = exitCode == 0 && waitForAdbTcpPort(5555)
+                        if (!success) {
+                            recordBindFailure(
+                                "Shevery",
+                                "command exit code $exitCode, port 5555 live: ${EnvironmentUtils.isAdbPortLive(5555)}"
+                            )
+                        }
+                    } else {
+                        recordBindFailure("Shevery", "binder was null")
                     }
                 } catch (e: Exception) {
-                    android.util.Log.d("Shevery", "Failed to bind TCP via Shizuku: ${e.message}")
+                    recordBindFailure("Shevery", e.message ?: e.javaClass.simpleName, e)
                 }
+            } else if (!success) {
+                recordBindFailure("Shevery", "binder is not active")
             }
 
             withContext(Dispatchers.Main) {
                 if (success) {
-                    Toast.makeText(this@HomeActivity, "Successfully bound ADB to TCP port 5555", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@HomeActivity, R.string.settings_tcp_5555_bind_success, Toast.LENGTH_SHORT).show()
                 } else {
-                    Toast.makeText(this@HomeActivity, "Failed to bind ADB to port 5555. Root or active Dhizuku/Shevery is required.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(
+                        this@HomeActivity,
+                        getString(R.string.settings_tcp_5555_bind_failed, failureReason),
+                        Toast.LENGTH_LONG
+                    ).show()
                 }
             }
         }
@@ -1253,5 +1292,4 @@ private fun DhizukuCard(onStartDhizuku: () -> Unit) {
         )
     }
 }
-
 

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -85,6 +85,9 @@ fun SettingsScreen() {
     var autoDisableUsbDebugging by remember {
         mutableStateOf(ShizukuSettings.getAutoDisableUsbDebugging())
     }
+    var tcpMode by remember {
+        mutableStateOf(ShizukuSettings.isTcpMode())
+    }
     var languageTag by remember {
         mutableStateOf(prefs.getString(LANGUAGE, "SYSTEM") ?: "SYSTEM")
     }
@@ -249,6 +252,16 @@ fun SettingsScreen() {
                     onCheckedChange = { enabled ->
                         ShizukuSettings.setAutoDisableUsbDebugging(enabled)
                         autoDisableUsbDebugging = ShizukuSettings.getAutoDisableUsbDebugging()
+                    }
+                )
+                SwitchSettingsRow(
+                    icon = R.drawable.ic_baseline_link_24,
+                    title = stringResource(R.string.settings_tcp_mode),
+                    summary = stringResource(R.string.settings_tcp_mode_summary),
+                    checked = tcpMode,
+                    onCheckedChange = { enabled ->
+                        ShizukuSettings.setTcpMode(enabled)
+                        tcpMode = ShizukuSettings.isTcpMode()
                     }
                 )
             }

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -385,4 +385,7 @@ With %1$s, in any terminal app, you can connect to and interact with the shell r
     <string name="settings_tcp_5555_title">TCP Binding 5555</string>
     <string name="settings_tcp_5555_summary">Bind local ADB server to port 5555 to keep it working without Wireless Debugging port updates.</string>
     <string name="settings_tcp_5555_button">Bind to 5555</string>
+    <string name="settings_tcp_5555_bind_success">Successfully bound ADB to TCP port 5555</string>
+    <string name="settings_tcp_5555_bind_failed">Failed to bind ADB to port 5555: %1$s</string>
+    <string name="settings_tcp_5555_bind_failed_generic">Root, Dhizuku, or active Shevery is required.</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR keeps only the TCP Mode pieces that are defensible from the current code/history:

- Restores the persistent TCP Mode Settings switch backed by `ShizukuSettings.isTcpMode()` / `setTcpMode()`.
- Keeps the home-screen Bind to 5555 card as a separate one-shot setup/diagnostic action.
- Adds route-specific diagnostics for Dhizuku, root, and active Shevery/Shizuku binding attempts.
- Requires the bind attempt to actually make `127.0.0.1:5555` live before reporting a successful bind.

## Why

The history shows two different concepts that should not be mixed:

1. TCP Mode is a watchdog restart setting: if ADB TCP is available, the watchdog can reconnect/start Shevery over local ADB TCP.
2. Bind to 5555 is a setup action: it attempts to make `adbd` listen on TCP 5555.

The Settings switch disappeared while the watchdog still depended on it, so restoring the switch is important. However, the active-Shevery/Shizuku bind route is not proven to work on all devices; user testing produced `Shevery: command exit code 1`. Because of that, this PR no longer keeps the speculative follow-up commits that treated delayed/nonzero active-Shevery setup as success. If the command fails or 5555 never becomes live, the button should fail honestly instead of pretending the bind worked.

## Testing

- `git diff --check`
- Reviewed history around `1dd28dc`, `54683cb`, `ac6e71a`, `83c1984`, and `c41c9bf`.
- User device testing showed the active-Shevery route can fail with command exit code 1, so the speculative success-dispatch commits were removed from this PR.
