### PR TITLE
Fix app-count refresh, manual stop, and Dhizuku readiness

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -153,6 +153,12 @@ abstract class HomeActivity : AppActivity() {
         }
     }
 
+    private val manageAppsLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        appsModel.load(onlyCount = true)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -247,7 +253,7 @@ abstract class HomeActivity : AppActivity() {
                                     },
                                     onAbout = ::showAboutDialog,
                                     onStop = ::showStopDialog,
-                                    onManageApps = { startActivity(Intent(this@HomeActivity, ApplicationManagementActivity::class.java)) },
+                                    onManageApps = { manageAppsLauncher.launch(Intent(this@HomeActivity, ApplicationManagementActivity::class.java)) },
                                     onTerminal = { startActivity(Intent(this@HomeActivity, ShellTutorialActivity::class.java)) },
                                     onStartRoot = ::startRoot,
                                     onStartWirelessAdb = { runWithLocalNetworkAccess(::startWirelessAdb) },
@@ -315,17 +321,14 @@ abstract class HomeActivity : AppActivity() {
         MaterialAlertDialogBuilder(this)
             .setMessage(R.string.dialog_stop_message)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
-                try {
-                    moe.shizuku.manager.service.WatchdogManager.expectingDeath = true
-                    Shizuku.exit()
-                } catch (_: Throwable) {
-                }
+                moe.shizuku.manager.service.WatchdogManager.stopServer(userInitiated = true)
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 
     private fun startRoot() {
+        moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest()
         startActivity(
             Intent(this, StarterActivity::class.java).apply {
                 putExtra(StarterActivity.EXTRA_IS_ROOT, true)
@@ -334,6 +337,7 @@ abstract class HomeActivity : AppActivity() {
     }
 
     private fun startWirelessAdb() {
+        moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             AdbDialogFragment().show(supportFragmentManager, "adb")
             return
@@ -440,6 +444,7 @@ abstract class HomeActivity : AppActivity() {
         Toast.makeText(this, R.string.home_diagnostics_copied, Toast.LENGTH_SHORT).show()
     }
     private fun startDhizukuMode() {
+        moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest()
         startActivity(
             Intent(this, StarterActivity::class.java).apply {
                 putExtra(StarterActivity.EXTRA_IS_ROOT, false)
@@ -449,6 +454,7 @@ abstract class HomeActivity : AppActivity() {
     }
 
     private fun bindTcp5555() {
+        moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest()
         lifecycleScope.launch(Dispatchers.IO) {
             var success = false
             // 1. Try via Dhizuku if enabled

--- a/manager/src/main/java/moe/shizuku/manager/management/ApplicationManagementActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/management/ApplicationManagementActivity.kt
@@ -165,6 +165,7 @@ class ApplicationManagementActivity : AppActivity() {
                                                 tick = tick,
                                                 onLimitedAdb = ::showAdbLimitedDialog,
                                                 onPermissionChanged = {
+                                                    setResult(RESULT_OK)
                                                     permissionTick.intValue++
                                                     viewModel.load(onlyCount = true)
                                                 }
@@ -187,6 +188,7 @@ class ApplicationManagementActivity : AppActivity() {
     }
 
     private fun selectAll(packages: List<PackageInfo>, granted: Boolean) {
+        var changed = false
         packages.forEach { packageInfo ->
             val applicationInfo = packageInfo.applicationInfo ?: return@forEach
             val uid = applicationInfo.uid
@@ -197,8 +199,12 @@ class ApplicationManagementActivity : AppActivity() {
                 } else {
                     AuthorizationManager.revoke(packageName, uid)
                 }
+                changed = true
             } catch (_: SecurityException) {
             }
+        }
+        if (changed) {
+            setResult(RESULT_OK)
         }
         permissionTick.intValue++
         viewModel.load(onlyCount = true)

--- a/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
@@ -14,6 +14,7 @@ class SheveryControlReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             ACTION_START_SERVER -> {
+                WatchdogManager.clearUserStopRequest()
                 WatchdogManager.attemptRestart(context.applicationContext)
             }
             ACTION_STOP_SERVER -> {

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -39,6 +39,7 @@ object WatchdogManager {
     private const val EXPECTED_DEATH_WINDOW_MS = 10_000L
     private const val WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS = 5L
     private const val DHIZUKU_BIND_TIMEOUT_MS = 10_000L
+    private const val KEY_USER_STOP_REQUESTED = "watchdog_user_stop_requested"
 
     @Volatile
     var expectingDeath = false
@@ -59,12 +60,21 @@ object WatchdogManager {
 
     private val restartInProgress = AtomicBoolean(false)
 
+    @Volatile
+    private var userStopRequested = false
+
     fun init(context: Context) {
         val appContext = context.applicationContext
         if (initialized) return
         initialized = true
 
+        userStopRequested = ShizukuSettings.getPreferences().getBoolean(KEY_USER_STOP_REQUESTED, false)
+
         logi("Initializing service watchdog")
+
+        Shizuku.addBinderReceivedListenerSticky {
+            clearUserStopRequest()
+        }
 
         Shizuku.addBinderDeadListener {
             onServiceDied(appContext)
@@ -83,7 +93,7 @@ object WatchdogManager {
         logd("Service died detected by watchdog")
 
         if (consumeExpectedDeath()) {
-            logi("Service death was expected (user stopped it). Resetting flag.")
+            logi("Service death was expected. Resetting expected-death flag.")
             return
         }
 
@@ -150,9 +160,31 @@ object WatchdogManager {
         notificationManager.notify(NOTIFICATION_ID, notification)
     }
 
+    fun clearUserStopRequest() {
+        setUserStopRequested(false)
+        expectingDeath = false
+    }
+
+    private fun setUserStopRequested(value: Boolean) {
+        userStopRequested = value
+        ShizukuSettings.getPreferences()
+            .edit()
+            .putBoolean(KEY_USER_STOP_REQUESTED, value)
+            .apply()
+    }
+
+    private fun isUserStopRequested(): Boolean {
+        return userStopRequested || ShizukuSettings.getPreferences().getBoolean(KEY_USER_STOP_REQUESTED, false)
+    }
+
     fun attemptRestart(context: Context) {
         val appContext = context.applicationContext
         clearExpectedDeathWhenStale()
+
+        if (isUserStopRequested()) {
+            logi("Skipping watchdog restart because the last stop was user-initiated")
+            return
+        }
 
         if (!restartInProgress.compareAndSet(false, true)) {
             logd("Restart already in progress, skipping duplicate watchdog restart")
@@ -175,12 +207,18 @@ object WatchdogManager {
         }
     }
 
-    fun stopServer() {
+    fun stopServer(userInitiated: Boolean = true) {
+        if (userInitiated) {
+            setUserStopRequested(true)
+        }
         expectingDeath = true
         try {
             Shizuku.exit()
         } catch (_: Throwable) {
             expectingDeath = false
+            if (userInitiated) {
+                setUserStopRequested(false)
+            }
         }
     }
 
@@ -266,6 +304,15 @@ object WatchdogManager {
         }
     }
 
+    private suspend fun waitForShizukuBinder(timeoutMs: Long = 10_000L): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (Shizuku.pingBinder()) return true
+            kotlinx.coroutines.delay(500)
+        }
+        return Shizuku.pingBinder()
+    }
+
     private suspend fun restartDhizuku(context: Context) {
         try {
             logi("Watchdog attempting Dhizuku restart...")
@@ -282,35 +329,37 @@ object WatchdogManager {
                 android.content.ComponentName(context.applicationContext, moe.shizuku.manager.dhizuku.DhizukuService::class.java)
             )
             var connection: android.content.ServiceConnection? = null
-            val serviceResult = withTimeoutOrNull(DHIZUKU_BIND_TIMEOUT_MS) {
-                suspendCancellableCoroutine<android.os.IBinder?> { cont ->
-                    val conn = object : android.content.ServiceConnection {
-                        override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
-                            if (cont.isActive) cont.resumeWith(Result.success(service))
+            try {
+                val serviceResult = withTimeoutOrNull(DHIZUKU_BIND_TIMEOUT_MS) {
+                    suspendCancellableCoroutine<android.os.IBinder?> { cont ->
+                        val conn = object : android.content.ServiceConnection {
+                            override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
+                                if (cont.isActive) cont.resumeWith(Result.success(service))
+                            }
+                            override fun onServiceDisconnected(name: android.content.ComponentName?) {}
                         }
-                        override fun onServiceDisconnected(name: android.content.ComponentName?) {}
-                    }
-                    connection = conn
-                    val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
-                    if (!bound && cont.isActive) {
-                        cont.resumeWith(Result.success(null))
-                    }
-                    cont.invokeOnCancellation {
-                        try {
-                            com.rosan.dhizuku.api.Dhizuku.unbindUserService(conn)
-                        } catch (e: Exception) { }
+                        connection = conn
+                        val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
+                        if (!bound && cont.isActive) {
+                            cont.resumeWith(Result.success(null))
+                        }
                     }
                 }
-            }
-            if (serviceResult == null) {
-                logd("Dhizuku service binding failed or timed out in watchdog")
-                return
-            }
-            try {
+                if (serviceResult == null) {
+                    logd("Dhizuku service binding failed or timed out in watchdog")
+                    return
+                }
                 val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
                 logi("Watchdog executing Shevery starter directly via Dhizuku Device Owner...")
                 dhizukuService.runCommand(Starter.internalCommand)
-                logi("Watchdog started Shevery server via Dhizuku shell successfully")
+                if (waitForShizukuBinder()) {
+                    logi("Watchdog verified Shevery binder after Dhizuku restart")
+                } else {
+                    logd("Watchdog Dhizuku starter command completed, but binder did not become available")
+                    if (ModuleSettings.isNotifyOnServiceDeath()) {
+                        showDeathNotification(context)
+                    }
+                }
             } finally {
                 connection?.let { conn ->
                     try {

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -66,7 +66,7 @@ class WatchdogService : Service() {
                 if (!healthy) {
                     logd("ErrorProtect: Service check failed. Stopping and restarting...")
                     withContext(Dispatchers.IO) {
-                        moe.shizuku.manager.service.WatchdogManager.stopServer()
+                        moe.shizuku.manager.service.WatchdogManager.stopServer(userInitiated = false)
                         moe.shizuku.manager.service.WatchdogManager.attemptRestart(applicationContext)
                     }
                 }
@@ -128,7 +128,7 @@ class WatchdogService : Service() {
 
     companion object {
         private const val CHANNEL_ID = "service_watchdog"
-        private const val NOTIFICATION_ID = 1002
+        private const val NOTIFICATION_ID = 1003
 
         fun reconcile(context: Context) {
             val appContext = context.applicationContext

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -69,8 +69,16 @@ class StarterActivity : AppActivity() {
 
         viewModel.output.observe(this) {
             val output = it.data.orEmpty().trim()
-            val finished = output.endsWith("info: shizuku_starter exit with 0") || (startedWithDhizuku && output.endsWith("✓ Initialization complete."))
-            if (!waitingForService && finished) {
+            val dhizukuFinished = startedWithDhizuku && output.endsWith("✓ Shevery binder verified.")
+            val finished = output.endsWith("info: shizuku_starter exit with 0")
+            if (!waitingForService && dhizukuFinished) {
+                waitingForService = true
+                moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest()
+                viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
+                window?.decorView?.postDelayed({
+                    if (!isFinishing) finish()
+                }, 3000)
+            } else if (!waitingForService && finished) {
                 waitingForService = true
                 viewModel.appendOutput("")
                 viewModel.appendOutput("Waiting for service...")
@@ -80,6 +88,7 @@ class StarterActivity : AppActivity() {
                         Shizuku.removeBinderReceivedListener(this)
                         binderReceivedListener = null
                         runOnUiThread {
+                            moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest()
                             viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
                             window?.decorView?.postDelayed({
                                 if (!isFinishing) finish()
@@ -290,6 +299,15 @@ private class ViewModel(context: Context, root: Boolean, dhizuku: Boolean, host:
         }
     }
 
+    private suspend fun waitForShizukuBinder(timeoutMs: Long = 10_000L): Boolean {
+        val deadline = android.os.SystemClock.elapsedRealtime() + timeoutMs
+        while (android.os.SystemClock.elapsedRealtime() < deadline) {
+            if (Shizuku.pingBinder()) return true
+            kotlinx.coroutines.delay(500)
+        }
+        return Shizuku.pingBinder()
+    }
+
     private fun startDhizuku(context: Context) {
         synchronized(outputLock) {
             sb.append("Starting with Dhizuku (Device Owner)...").append('\n').append('\n')
@@ -330,36 +348,31 @@ private class ViewModel(context: Context, root: Boolean, dhizuku: Boolean, host:
                     android.content.ComponentName(context.applicationContext, moe.shizuku.manager.dhizuku.DhizukuService::class.java)
                 )
                 var connection: android.content.ServiceConnection? = null
-                val serviceResult = kotlinx.coroutines.withTimeoutOrNull(10000) {
-                    kotlinx.coroutines.suspendCancellableCoroutine<android.os.IBinder?> { cont ->
-                        val conn = object : android.content.ServiceConnection {
-                            override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
-                                if (cont.isActive) cont.resumeWith(Result.success(service))
+                try {
+                    val serviceResult = kotlinx.coroutines.withTimeoutOrNull(10000) {
+                        kotlinx.coroutines.suspendCancellableCoroutine<android.os.IBinder?> { cont ->
+                            val conn = object : android.content.ServiceConnection {
+                                override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
+                                    if (cont.isActive) cont.resumeWith(Result.success(service))
+                                }
+                                override fun onServiceDisconnected(name: android.content.ComponentName?) {}
                             }
-                            override fun onServiceDisconnected(name: android.content.ComponentName?) {}
-                        }
-                        connection = conn
-                        val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
-                        if (!bound && cont.isActive) {
-                            cont.resumeWith(Result.success(null))
-                        }
-                        cont.invokeOnCancellation {
-                            try {
-                                com.rosan.dhizuku.api.Dhizuku.unbindUserService(conn)
-                            } catch (e: Exception) { }
+                            connection = conn
+                            val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
+                            if (!bound && cont.isActive) {
+                                cont.resumeWith(Result.success(null))
+                            }
                         }
                     }
-                }
 
-                if (serviceResult == null) {
-                    appendLine("✗ Dhizuku service binding failed or timed out.")
-                    appendLine("  Make sure Dhizuku is set as Device Owner and is active.")
-                    postResult(DhizukuException("Dhizuku service binding failed"))
-                    return@launch
-                }
-                appendLine("✓ Dhizuku service connected\n")
+                    if (serviceResult == null) {
+                        appendLine("✗ Dhizuku service binding failed or timed out.")
+                        appendLine("  Make sure Dhizuku is set as Device Owner and is active.")
+                        postResult(DhizukuException("Dhizuku service binding failed"))
+                        return@launch
+                    }
+                    appendLine("✓ Dhizuku service connected\n")
 
-                try {
                     val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
 
                     appendLine("Executing Shevery starter directly via Dhizuku Device Owner...")
@@ -368,9 +381,15 @@ private class ViewModel(context: Context, root: Boolean, dhizuku: Boolean, host:
 
                     appendLine("✓ Starter command sent to Dhizuku shell.")
                     appendLine("Waiting for Shevery service to initialize...")
-                    kotlinx.coroutines.delay(3000)
-                    appendLine("✓ Initialization complete.")
-                    postResult()
+                    if (waitForShizukuBinder()) {
+                        appendLine("✓ Shevery binder verified.")
+                        postResult()
+                    } else {
+                        appendLine("✗ Starter command completed, but Shevery service did not become available.")
+                        appendLine("  Direct Dhizuku startup can fail when the Device Owner context cannot provide the same shell/root environment as ADB or root.")
+                        appendLine("  Try starting with Wireless ADB or root, then copy diagnostics if this repeats.")
+                        postResult(DhizukuException("Dhizuku starter did not publish a Shevery binder"))
+                    }
                 } finally {
                     connection?.let { conn ->
                         try {


### PR DESCRIPTION
## Summary

This PR fixes several standalone reliability regressions without pulling in the Wireless ADB or TCP Mode PR branches.

## What changed

- Refreshes the home authorized-app count after returning from Application Management.
- Marks authorization changes with `RESULT_OK` so the home screen knows to reload.
- Refreshes local management state after single-app and select-all permission changes.
- Persists intentional manual Stop state so watchdog/ErrorProtect does not restart after a user-initiated stop.
- Clears manual-stop suppression when the user explicitly starts again or when a binder is received.
- Keeps internal ErrorProtect recovery using non-user-initiated stop semantics.
- Gives the watchdog foreground-service notification a distinct notification ID so it does not collide with the main Shevery control notification.
- Verifies Dhizuku direct-start binder readiness before reporting success.
- Adds watchdog-side Dhizuku readiness validation and failure notification surfacing.

## Why

The package-list freshness fix was already present, but Shevery's modified UI still needed a return-time refresh so TalkBack/visual users see the authorized-app count update immediately after granting or denying apps. The watchdog also needs to distinguish a real crash from a deliberate user stop, and Dhizuku direct start should not claim success until the Shevery/Shizuku binder is actually usable.

## Testing

- `git diff --check`
- Authorized-app count behavior was device-tested: denying an app and backing out updates immediately.
- Local Gradle compile attempted where possible, but blocked in Codex by missing Android SDK configuration.
