### PR TITLE
Label icon-only controls for TalkBack

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -610,7 +610,7 @@ private fun HomeScreen(
                         IconButton(onClick = { moreOpen = true }) {
                             ShizukuIcon(
                                 icon = R.drawable.ic_more_vert_24,
-                                contentDescription = null
+                                contentDescription = stringResource(R.string.accessibility_more_options)
                             )
                         }
                         DropdownMenu(

--- a/manager/src/main/java/moe/shizuku/manager/management/ApplicationManagementActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/management/ApplicationManagementActivity.kt
@@ -105,7 +105,10 @@ class ApplicationManagementActivity : AppActivity() {
 
                             Box {
                                 IconButton(onClick = { menuExpanded = true }) {
-                                    ShizukuIcon(R.drawable.ic_more_vert_24)
+                                    ShizukuIcon(
+                                        R.drawable.ic_more_vert_24,
+                                        contentDescription = stringResource(R.string.accessibility_more_options)
+                                    )
                                 }
                                 DropdownMenu(
                                     expanded = menuExpanded,

--- a/manager/src/main/java/moe/shizuku/manager/module/catalog/CatalogScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/catalog/CatalogScreen.kt
@@ -478,12 +478,19 @@ private fun ModuleDetailScreen(
                 title = { Text(module.moduleName, maxLines = 1, overflow = TextOverflow.Ellipsis) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Rounded.ArrowBack,
+                            contentDescription = "Back"
+                        )
                     }
                 },
                 actions = {
                     IconButton(onClick = onViewOnGitHub) {
-                        ShizukuIcon(R.drawable.ic_outline_open_in_new_24, modifier = Modifier.size(20.dp))
+                        ShizukuIcon(
+                            R.drawable.ic_outline_open_in_new_24,
+                            contentDescription = stringResource(R.string.accessibility_open_on_github),
+                            modifier = Modifier.size(20.dp)
+                        )
                     }
                 }
             )

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -128,7 +128,8 @@ class StarterActivity : AppActivity() {
                 ShizukuLazyScaffold(
                     title = stringResource(R.string.starter),
                     onNavigateUp = { finish() },
-                    navigationIcon = R.drawable.ic_close_24
+                    navigationIcon = R.drawable.ic_close_24,
+                    navigationContentDescription = R.string.accessibility_close
                 ) {
                     item {
                         val startedWithRoot = intent.getBooleanExtra(EXTRA_IS_ROOT, true)

--- a/manager/src/main/java/moe/shizuku/manager/ui/compose/ShizukuExpressive.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ui/compose/ShizukuExpressive.kt
@@ -147,6 +147,7 @@ fun ShizukuScaffold(
     modifier: Modifier = Modifier,
     onNavigateUp: (() -> Unit)? = null,
     navigationIcon: Int = R.drawable.ic_arrow_back_24,
+    @StringRes navigationContentDescription: Int = R.string.accessibility_navigate_up,
     actions: @Composable RowScope.() -> Unit = {},
     content: @Composable (PaddingValues) -> Unit
 ) {
@@ -165,7 +166,10 @@ fun ShizukuScaffold(
                 navigationIcon = {
                     if (onNavigateUp != null) {
                         IconButton(onClick = onNavigateUp) {
-                            ShizukuIcon(navigationIcon)
+                            ShizukuIcon(
+                                navigationIcon,
+                                contentDescription = stringResource(navigationContentDescription)
+                            )
                         }
                     }
                 },
@@ -186,6 +190,7 @@ fun ShizukuLazyScaffold(
     modifier: Modifier = Modifier,
     onNavigateUp: (() -> Unit)? = null,
     navigationIcon: Int = R.drawable.ic_arrow_back_24,
+    @StringRes navigationContentDescription: Int = R.string.accessibility_navigate_up,
     actions: @Composable RowScope.() -> Unit = {},
     contentPadding: PaddingValues = PaddingValues(start = 16.dp, top = 8.dp, end = 16.dp, bottom = 16.dp),
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(10.dp),
@@ -196,6 +201,7 @@ fun ShizukuLazyScaffold(
         modifier = modifier,
         onNavigateUp = onNavigateUp,
         navigationIcon = navigationIcon,
+        navigationContentDescription = navigationContentDescription,
         actions = actions
     ) { innerPadding ->
         LazyColumn(

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -4,6 +4,12 @@
     <!-- To translators: you can leave your here -->
     <string name="translation_contributors" />
 
+    <!-- Accessibility -->
+    <string name="accessibility_navigate_up">Navigate up</string>
+    <string name="accessibility_close">Close</string>
+    <string name="accessibility_more_options">More options</string>
+    <string name="accessibility_open_on_github">Open on GitHub</string>
+
     <!-- Home - Status -->
     <string name="home_status_service_is_running">%1$s is running</string>
     <string name="home_status_service_not_running">%1$s is not running</string>


### PR DESCRIPTION
## Summary

This PR improves TalkBack accessibility by labeling icon-only controls that were previously unlabeled or poorly labeled, without changing the visible UI.

## What changed

- Adds shared accessibility strings for navigation, close, more options, and GitHub actions.
- Labels home-screen and app-management overflow icon buttons as More options.
- Labels shared scaffold navigation icons while allowing close-style screens to announce Close instead of Navigate up.
- Labels the GitHub icon-only action in module detail.
- Leaves decorative icons inside already-labeled text controls as decorative.

## Why

Android accessibility guidance expects meaningful interactive controls to expose useful labels to assistive technologies. This keeps the visual design unchanged for sighted users while making icon-only controls understandable for TalkBack users.

## Testing

- Audited `IconButton` blocks for content descriptions.
- Audited remaining `contentDescription = null` usages to keep decorative icons decorative.
- `git diff --check`
- Local Gradle compile attempted where possible, but blocked in Codex by missing Android SDK configuration.
