### PR TITLE
Add copy button for Gemini AI explanation

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/logs/ComputScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/logs/ComputScreen.kt
@@ -644,6 +644,32 @@ fun ComputScreen() {
                         
                         if (aiExplanation.isNotBlank()) {
                             HorizontalDivider(color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.15f))
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.comput_gemini_explain),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                IconButton(
+                                    onClick = {
+                                        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                                        clipboard.setPrimaryClip(ClipData.newPlainText("Gemini Explanation", aiExplanation))
+                                        Toast.makeText(context, context.getString(R.string.comput_copied_to_clipboard), Toast.LENGTH_SHORT).show()
+                                    }
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.ContentCopy,
+                                        contentDescription = stringResource(R.string.comput_copy_explanation),
+                                        modifier = Modifier.size(18.dp),
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            }
                             SelectionContainer {
                                 Text(
                                     text = aiExplanation,

--- a/manager/src/main/java/moe/shizuku/manager/module/ModulesScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModulesScreen.kt
@@ -6,6 +6,7 @@
 
 package moe.shizuku.manager.module
 
+import android.content.ClipData
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.net.Uri
@@ -41,10 +42,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ContentCopy
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
@@ -52,6 +56,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -407,10 +413,34 @@ fun ModulesScreen(onOpenWebUi: (String) -> Unit) {
                             CircularProgressIndicator()
                         }
                     } else if (aiExplanation != null) {
-                        Text(
-                            text = aiExplanation!!,
-                            style = MaterialTheme.typography.bodyMedium
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            val ctx = LocalContext.current
+                            IconButton(
+                                onClick = {
+                                    val clipboard = ctx.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                                    clipboard.setPrimaryClip(ClipData.newPlainText("Gemini Explanation", aiExplanation!!))
+                                    Toast.makeText(ctx, ctx.getString(moe.shizuku.manager.R.string.comput_copied_to_clipboard), Toast.LENGTH_SHORT).show()
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.ContentCopy,
+                                    contentDescription = stringResource(R.string.comput_copy_explanation),
+                                    modifier = Modifier.size(18.dp),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        SelectionContainer {
+                            Text(
+                                text = aiExplanation!!,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
                     } else {
                         val apiKey = ModuleSettings.getComputApiKey()
                         val hasApiKey = apiKey.isNotBlank()

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -455,6 +455,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="comput_use_command">Use command</string>
     <string name="comput_copied_to_clipboard">Copied to clipboard</string>
     <string name="comput_copy_command">Copy command</string>
+    <string name="comput_copy_explanation">Copy explanation</string>
     <string name="comput_console_macros">Console Macros</string>
     <string name="comput_stop">Stop (%1$d)</string>
     <string name="comput_record_macro">Record Macro</string>


### PR DESCRIPTION
## Summary

Adds a copy-to-clipboard button next to the Gemini AI explanation text in both screens that display it.

Closes #68.

## Changes

**`ComputScreen.kt`** — Added a header row with a copy `IconButton` above the existing `SelectionContainer` that holds the Gemini explanation text. Uses the same clipboard pattern already used for copying ADB output and commands elsewhere in the same file.

**`ModulesScreen.kt`** — Replaced the bare `Text(aiExplanation)` with a `SelectionContainer` wrapping the explanation (was missing — text was not selectable), plus a copy `IconButton` aligned to the end. Added required imports (`Icon`, `IconButton`, `Icons`, `ContentCopy`, `ClipData`, `SelectionContainer`).

**`strings.xml`** — Added `comput_copy_explanation` string resource for the copy button content description.

## Testing

⚠️ **Not compiled or device-tested.** I do not have a Google AI Studio API key, so I cannot reach the screen where the Gemini explanation and the new copy button appear. The implementation follows existing copy-to-clipboard patterns already used in the same files (ADB output copy at line ~546, Commandium copy at line ~784), so it should work, but compilation and runtime verification are still needed.

What still needs testing:
- Compilation with Android SDK (Gradle build)
- Visual layout on narrow screens (Row + SpaceBetween with short label)
- Clipboard actually copies the explanation text
- SelectionContainer allows text selection in ModulesScreen dialog