### PR TITLE
Fix race condition causing false ECONNREFUSED error

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/AdbDialogFragment.kt
@@ -42,6 +42,7 @@ class AdbDialogFragment : DialogFragment() {
 
     private lateinit var adbMdns: AdbMdns
     private val port = MutableLiveData<Int>()
+    private var startCommitted = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
@@ -151,6 +152,10 @@ class AdbDialogFragment : DialogFragment() {
 
     private fun startAndDismiss(port: Int) {
         if (!isValidAdbPort(port)) return
+        if (startCommitted) return
+
+        startCommitted = true
+        adbMdns.stop()
 
         val host = "127.0.0.1"
         val intent = Intent(context, StarterActivity::class.java).apply {


### PR DESCRIPTION
## Summary

Fixes a race condition in `AdbDialogFragment` where two concurrent paths can each launch a separate `StarterActivity`, producing a spurious ECONNREFUSED error dialog even though Shizuku successfully starts.

Closes #70.

## Root Cause

`AdbDialogFragment.onDialogShow()` starts three things simultaneously:

1. **mDNS discovery** (`adbMdns.start()`) — resolves `_adb-tls-connect._tcp` and calls `startAndDismiss(discoveredPort)` via LiveData observer
2. **`tryTcpModePortFirst()`** — if TCP mode is on and port 5555 is live, calls `startAndDismiss(5555)`
3. **Neutral button** — if the user taps the "5555" button, calls `startAndDismiss(5555)`

`startAndDismiss()` has **no idempotency guard**. If mDNS resolves a dynamic wireless debugging port (e.g. 37021) around the same time the user taps the neutral button (or `tryTcpModePortFirst` fires), two `StarterActivity` instances are launched with different ports:

- The dynamic-port attempt **succeeds** → Shizuku starts
- The 5555 attempt **fails** with ECONNREFUSED after exhausting 8 retries → shows error dialog

The user sees the error, swipes the app away, reopens it, and finds Shizuku running — exactly matching the issue report.

## Fix

Add a one-shot guard in `startAndDismiss()`:

```kotlin
private var startCommitted = false

private fun startAndDismiss(port: Int) {
    if (!isValidAdbPort(port)) return
    if (startCommitted) return

    startCommitted = true
    adbMdns.stop()
    // ... launch StarterActivity and dismiss
}
```

Port validation happens **before** the guard so an invalid port never locks out a valid second attempt. `adbMdns.stop()` is called immediately after committing to stop further mDNS callbacks. A plain `Boolean` is sufficient — all three call sites (button click, LiveData observer, `withContext(Dispatchers.Main)`) execute on the main thread.

`adbMdns.stop()` is already called in `onDismiss()`, and `AdbMdns.stop()` is idempotent (`if (!running) return`), so calling it earlier is safe.

## Changes

- `AdbDialogFragment.kt` — 5 lines added (1 field + 4 lines in `startAndDismiss`)

## Testing

⚠️ **Not compiled or device-tested** — no Android SDK on the development machine. The fix is 5 additive lines with no control flow changes to existing code. The guard pattern is a standard one-shot boolean, and the idempotency of `adbMdns.stop()` was verified by reading the source.

What still needs testing:
- Compilation with Android SDK
- Verify that when mDNS resolves and the neutral button is tapped near-simultaneously, only one `StarterActivity` launches
- Verify the error dialog no longer appears when the dynamic-port path succeeds