### PR TITLE
Fix accessibility issues in app management dialog

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/management/ApplicationManagementActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/management/ApplicationManagementActivity.kt
@@ -5,6 +5,7 @@ package moe.shizuku.manager.management
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
@@ -16,7 +17,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.AssistChip
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -138,11 +139,19 @@ class ApplicationManagementActivity : AppActivity() {
                     when {
                         packagesResource == null -> {
                             item {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    contentAlignment = Alignment.Center
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 24.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.spacedBy(12.dp)
                                 ) {
                                     LoadingIndicator(Modifier.size(36.dp))
+                                    Text(
+                                        text = stringResource(R.string.app_management_loading),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
                                 }
                             }
                         }
@@ -227,7 +236,7 @@ class ApplicationManagementActivity : AppActivity() {
     }
 
     private fun showAdbLimitedDialog() {
-        MaterialAlertDialogBuilder(this)
+        val dialog = MaterialAlertDialogBuilder(this)
             .setTitle(R.string.app_management_dialog_adb_is_limited_title)
             .setMessage(
                 getString(R.string.app_management_dialog_adb_is_limited_message, Helps.ADB.get())
@@ -235,6 +244,9 @@ class ApplicationManagementActivity : AppActivity() {
             )
             .setPositiveButton(android.R.string.ok, null)
             .show()
+
+        dialog.findViewById<android.widget.TextView>(android.R.id.message)?.movementMethod =
+            LinkMovementMethod.getInstance()
     }
 }
 
@@ -326,12 +338,17 @@ private fun AppPermissionRow(
                 overflow = TextOverflow.Ellipsis
             )
             if (requiresRoot) {
-                AssistChip(
-                    onClick = {},
-                    label = {
-                        Text(stringResource(R.string.app_management_item_summary_requires_root))
-                    }
-                )
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = MaterialTheme.colorScheme.secondaryContainer
+                ) {
+                    Text(
+                        text = stringResource(R.string.app_management_item_summary_requires_root),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+                }
             }
         }
         ExpressiveSwitch(

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="app_management_dialog_adb_is_limited_title">The permission of adb is limited</string>
     <string name="app_management_dialog_adb_is_limited_message"><![CDATA[It\'s highly possible that your device manufacturer limits the permission of adb.<p>There may be a solution for your system in <b><a href="%1$s">this document</a></b>.]]></string>
     <string name="app_management_item_summary_requires_root">* requires Shevery runs with root</string>
+    <string name="app_management_loading">Loading apps…</string>
 
     <!-- Terminal -->
     <string name="home_terminal_title">Use Shevery in terminal apps</string>


### PR DESCRIPTION
## Summary
Fixes 2 MAJOR + 1 MINOR accessibility issues found in an audit of `ApplicationManagementActivity.kt` (the app management dialog), with fixes agreed upon by independent reviews across multiple models.

## Changes

1. **Replace dead focusable AssistChip with non-interactive Surface** (`AppPermissionRow`)
   - The "requires root" chip had `onClick = {}` — announced as a button by TalkBack/Switch Access but did nothing
   - Now a pill-shaped `Surface` + `Text` (secondaryContainer, RoundedCornerShape(50)) — same visual, zero click semantics

2. **Make ADB-limited dialog HTML link actionable** (`showAdbLimitedDialog`)
   - The message contains an `<a href>` link but the message TextView had no `LinkMovementMethod`, so it was dead for all users
   - Set `LinkMovementMethod.getInstance()` on `android.R.id.message` after `.show()`

3. **Add visible "Loading apps…" label** to the loading state
   - LoadingIndicator had no accessible label; added visible `Text` beneath it (new string `app_management_loading`) — scales with font settings and announces clearly

## Verification

- All changes agreed by independent review across multiple models (GLM-5.2, Nemotron-120B)
- `LinkMovementMethod` pattern matches existing usage in `RequestPermissionActivity.kt`
- No new dependencies; imports cleaned (removed unused `AssistChip`)