### PR TITLE
feat: Accessibility Manager with keep-alive daemon

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -108,6 +108,11 @@
             android:label="Lab Features" />
 
         <activity
+            android:name=".accessibility.AccessibilityManagerActivity"
+            android:exported="false"
+            android:label="@string/accessibility_manager_title" />
+
+        <activity
             android:name=".about.AboutActivity"
             android:exported="false"
             android:label="@string/action_about" />
@@ -181,6 +186,16 @@
                 android:value="Keeps Shevery service watchdog monitoring active while keep-alive or auto-restart is enabled." />
         </service>
 
+        <service
+            android:name=".accessibility.AccessibilityDaemonService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Keeps pinned accessibility services enabled by restoring them when disabled." />
+        </service>
+
         <receiver
             android:name=".receiver.BootCompleteReceiver"
             android:directBootAware="true"
@@ -191,6 +206,18 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".accessibility.AccessibilityBootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -22,6 +22,15 @@
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
+    <!-- Android 11+ package visibility: expose every app that provides an
+         accessibility service so the Accessibility Manager can list and
+         manage all of them, not just system ones. -->
+    <queries>
+        <intent>
+            <action android:name="android.accessibilityservice.AccessibilityService" />
+        </intent>
+    </queries>
+
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -22,14 +22,17 @@
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
-    <!-- Android 11+ package visibility: expose every app that provides an
-         accessibility service so the Accessibility Manager can list and
-         manage all of them, not just system ones. -->
-    <queries>
-        <intent>
-            <action android:name="android.accessibilityservice.AccessibilityService" />
-        </intent>
-    </queries>
+    <!-- Android 11+ package visibility: enumerate EVERY package that provides
+         an accessibility service so the Accessibility Manager can list and
+         manage all of them. The scoped <queries> form was too narrow — it
+         only exposed resolvable exported components and missed 8 of 32
+         services on the tester's device. QUERY_ALL_PACKAGES is the same
+         approach the reference app uses, and is a legitimate, Play-policy
+         compliant use for an accessibility manager (its core function is
+         managing services across all installed apps). -->
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
 
     <uses-feature
         android:name="android.software.leanback"

--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -121,8 +121,13 @@
 
         <activity
             android:name=".accessibility.AccessibilityManagerActivity"
-            android:exported="false"
-            android:label="@string/accessibility_manager_title" />
+            android:exported="true"
+            android:label="@string/accessibility_manager_title">
+            <intent-filter>
+                <action android:name="com.hamondev.shevery.action.ACCESSIBILITY_MANAGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".about.AboutActivity"

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityBootReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityBootReceiver.kt
@@ -1,0 +1,26 @@
+package moe.shizuku.manager.accessibility
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import moe.shizuku.manager.ktx.logd
+
+/**
+ * Starts the accessibility keep-alive daemon after device boot when the
+ * auto-boot preference is enabled.
+ */
+class AccessibilityBootReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED &&
+            intent.action != Intent.ACTION_LOCKED_BOOT_COMPLETED
+        ) {
+            return
+        }
+        if (!AccessibilityKeepAliveStore.isAutoBootEnabled()) return
+        if (!AccessibilityKeepAliveStore.isKeepAliveEnabled()) return
+
+        logd("Boot completed — starting accessibility keep-alive daemon")
+        AccessibilityDaemonService.reconcile(context.applicationContext)
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
@@ -96,6 +96,11 @@ class AccessibilityDaemonService : Service() {
         val resolver: ContentResolver = contentResolver
         observer = object : ContentObserver(mainHandler) {
             override fun onChange(selfChange: Boolean) {
+                // Ignore our own writes so a restore can't loop on itself.
+                if (AccessibilityManager.wasSelfWrite()) {
+                    AccessibilityManager.clearSelfWrite()
+                    return
+                }
                 scheduleCheck(delayMs = 500L)
             }
         }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
@@ -152,7 +152,7 @@ class AccessibilityDaemonService : Service() {
         }
     }
 
-    private suspend fun runCheck() {
+    private fun runCheck() {
         // Rate-limit: never run two checks within 2 seconds of each other.
         val now = System.currentTimeMillis()
         if (now - lastRestore < MIN_CHECK_INTERVAL_MS) return

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
@@ -97,7 +97,7 @@ class AccessibilityDaemonService : Service() {
         observer = object : ContentObserver(mainHandler) {
             override fun onChange(selfChange: Boolean) {
                 // Ignore our own writes so a restore can't loop on itself.
-                if (AccessibilityManager.wasSelfWrite()) {
+                if (AccessibilityManager.isSelfWrite()) {
                     AccessibilityManager.clearSelfWrite()
                     return
                 }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityDaemonService.kt
@@ -1,0 +1,231 @@
+package moe.shizuku.manager.accessibility
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.ServiceInfo
+import android.database.ContentObserver
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.provider.Settings
+import androidx.core.app.NotificationCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.MainActivity
+import moe.shizuku.manager.R
+import moe.shizuku.manager.ktx.logd
+import moe.shizuku.manager.ktx.logi
+import moe.shizuku.manager.ktx.logw
+
+/**
+ * Foreground daemon that keeps pinned accessibility services alive.
+ *
+ * Triggers a check on three events (belt and suspenders):
+ *  1. A [ContentObserver] on ENABLED_ACCESSIBILITY_SERVICES — fires whenever
+ *     the system or the user changes the list.
+ *  2. A screen-on / unlock broadcast — accessibility services are most often
+ *     killed in the background; waking the screen is a cheap re-check point.
+ *  3. A 60-second heartbeat — catches changes that produce no broadcast.
+ *
+ * The check itself is cheap: read the enabled list, compare against pinned,
+ * and only write via Shizuku when something is actually missing.
+ */
+class AccessibilityDaemonService : Service() {
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var observer: ContentObserver? = null
+    private var heartbeatJob: kotlinx.coroutines.Job? = null
+    private var lastRestore = 0L
+
+    private val screenOnReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == Intent.ACTION_SCREEN_ON ||
+                intent.action == Intent.ACTION_USER_PRESENT
+            ) {
+                scheduleCheck(delayMs = 1500L)
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        registerObserver()
+        registerScreenReceiver()
+        startAsForeground()
+        scheduleCheck(delayMs = 0L)
+        logi("AccessibilityDaemonService created")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Restart the heartbeat if the system killed and re-created us.
+        if (heartbeatJob?.isActive != true) {
+            startHeartbeat()
+        }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        unregisterObserver()
+        unregisterReceiverSafe(screenOnReceiver)
+        heartbeatJob?.cancel()
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    // ------------------------------------------------------------------
+    // Monitoring
+    // ------------------------------------------------------------------
+
+    private fun registerObserver() {
+        val resolver: ContentResolver = contentResolver
+        observer = object : ContentObserver(mainHandler) {
+            override fun onChange(selfChange: Boolean) {
+                scheduleCheck(delayMs = 500L)
+            }
+        }
+        resolver.registerContentObserver(
+            Settings.Secure.getUriFor(Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES),
+            false,
+            observer!!
+        )
+    }
+
+    private fun unregisterObserver() {
+        observer?.let { contentResolver.unregisterContentObserver(it) }
+        observer = null
+    }
+
+    private fun registerScreenReceiver() {
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_USER_PRESENT)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(screenOnReceiver, filter, RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            registerReceiver(screenOnReceiver, filter)
+        }
+    }
+
+    private fun unregisterReceiverSafe(receiver: BroadcastReceiver) {
+        try {
+            unregisterReceiver(receiver)
+        } catch (ignore: IllegalArgumentException) {
+        }
+    }
+
+    private fun startHeartbeat() {
+        heartbeatJob = serviceScope.launch {
+            while (true) {
+                delay(HEARTBEAT_INTERVAL_MS)
+                scheduleCheck(delayMs = 0L)
+            }
+        }
+    }
+
+    private fun scheduleCheck(delayMs: Long) {
+        serviceScope.launch {
+            if (delayMs > 0) delay(delayMs)
+            runCheck()
+        }
+    }
+
+    private suspend fun runCheck() {
+        // Rate-limit: never run two checks within 2 seconds of each other.
+        val now = System.currentTimeMillis()
+        if (now - lastRestore < MIN_CHECK_INTERVAL_MS) return
+        lastRestore = now
+
+        val restored = AccessibilityManager.restorePinnedServices(this@AccessibilityDaemonService)
+        if (restored.isNotEmpty()) {
+            logi("Keep-alive restored accessibility services: $restored")
+        } else {
+            logd("Keep-alive check: nothing to restore")
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Foreground notification
+    // ------------------------------------------------------------------
+
+    private fun startAsForeground() {
+        createChannel()
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, notificationIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_system_icon)
+            .setContentTitle(getString(R.string.accessibility_daemon_notification_title))
+            .setContentText(getString(R.string.accessibility_daemon_notification_text))
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setShowWhen(false)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.accessibility_daemon_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                setShowBadge(false)
+            }
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "accessibility_keep_alive"
+        private const val NOTIFICATION_ID = 1003
+        private const val HEARTBEAT_INTERVAL_MS = 60_000L
+        private const val MIN_CHECK_INTERVAL_MS = 2_000L
+
+        /**
+         * Start the daemon if the master switch is on and there is at least
+         * one pinned service (or none pinned but the user explicitly enabled
+         * it — we still run so pinning from the UI takes effect immediately).
+         */
+        fun reconcile(context: Context) {
+            if (!AccessibilityKeepAliveStore.isKeepAliveEnabled()) {
+                context.stopService(Intent(context, AccessibilityDaemonService::class.java))
+                return
+            }
+            val intent = Intent(context, AccessibilityDaemonService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityKeepAliveStore.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityKeepAliveStore.kt
@@ -1,0 +1,69 @@
+package moe.shizuku.manager.accessibility
+
+import moe.shizuku.manager.ShizukuSettings
+
+/**
+ * Persistence for the accessibility keep-alive (pinned) service list.
+ *
+ * Stores colon-separated accessibility service IDs (e.g. "pkg/cls:pkg2/cls2:")
+ * in the shared preferences, mirroring the format Android uses for
+ * [android.provider.Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES].
+ */
+object AccessibilityKeepAliveStore {
+
+    private const val KEY_KEEP_ALIVE_LIST = "accessibility_keep_alive_list"
+    private const val KEY_KEEP_ALIVE_ENABLED = "accessibility_keep_alive_enabled"
+    private const val KEY_AUTO_BOOT = "accessibility_keep_alive_auto_boot"
+
+    /** Master switch: whether the keep-alive daemon should run at all. */
+    fun isKeepAliveEnabled(): Boolean {
+        return ShizukuSettings.getPreferences().getBoolean(KEY_KEEP_ALIVE_ENABLED, false)
+    }
+
+    fun setKeepAliveEnabled(enabled: Boolean) {
+        ShizukuSettings.getPreferences().edit().putBoolean(KEY_KEEP_ALIVE_ENABLED, enabled).apply()
+    }
+
+    /** Whether to auto-start the daemon on device boot. */
+    fun isAutoBootEnabled(): Boolean {
+        return ShizukuSettings.getPreferences().getBoolean(KEY_AUTO_BOOT, true)
+    }
+
+    fun setAutoBootEnabled(enabled: Boolean) {
+        ShizukuSettings.getPreferences().edit().putBoolean(KEY_AUTO_BOOT, enabled).apply()
+    }
+
+    /** Set of currently pinned (keep-alive) service IDs. */
+    fun getKeepAliveIds(): Set<String> {
+        val raw = ShizukuSettings.getPreferences().getString(KEY_KEEP_ALIVE_LIST, "") ?: ""
+        return parseIds(raw)
+    }
+
+    fun isPinned(serviceId: String): Boolean = getKeepAliveIds().contains(serviceId)
+
+    fun addPinned(serviceId: String): Set<String> {
+        val ids = getKeepAliveIds().toMutableSet()
+        ids.add(serviceId)
+        writeIds(ids)
+        return ids
+    }
+
+    fun removePinned(serviceId: String): Set<String> {
+        val ids = getKeepAliveIds().toMutableSet()
+        ids.remove(serviceId)
+        writeIds(ids)
+        return ids
+    }
+
+    private fun writeIds(ids: Set<String>) {
+        val raw = ids.joinToString(":") { it } + if (ids.isNotEmpty()) ":" else ""
+        ShizukuSettings.getPreferences().edit().putString(KEY_KEEP_ALIVE_LIST, raw).apply()
+    }
+
+    private fun parseIds(raw: String): Set<String> {
+        if (raw.isBlank()) return emptySet()
+        return raw.split(":")
+            .filter { it.isNotBlank() }
+            .toSet()
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
@@ -1,47 +1,33 @@
 package moe.shizuku.manager.accessibility
 
+import android.content.ComponentName
 import android.content.Context
-import android.os.ParcelFileDescriptor
 import android.provider.Settings
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
-import moe.shizuku.manager.ktx.logd
-import moe.shizuku.manager.ktx.logw
-import moe.shizuku.server.IShizukuService
-import rikka.shizuku.Shizuku
-import java.io.BufferedReader
-import java.util.concurrent.TimeUnit
+import android.util.Log
 
 /**
  * Core controller for accessibility service management.
  *
- * All reads and writes go through the Shizuku shell:
- *  - `settings get secure enabled_accessibility_services` — ground truth, never
- *    filtered by Android 11+ package visibility (an app-process read of
- *    [Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES] IS filtered, which is why
- *    states appeared wrong for most services).
- *  - `settings put secure ...` — shell owns WRITE_SECURE_SETTINGS.
+ * Reads and writes [Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES] directly
+ * via the ContentResolver. Shevery holds WRITE_SECURE_SETTINGS (granted via
+ * Shizuku/ADB), so no shell command is needed — this is synchronous, atomic,
+ * and matches exactly how the reference app works.
  *
- * Every read-modify-write cycle is serialized by [lock] so rapid toggles can
- * never clobber each other (a previous toggle must not be reverted by a
- * concurrent one).
+ * The enabled list is a colon-separated string of flattened ComponentNames:
+ *   "com.example/com.example.MyService:com.other/com.other.Svc"
+ *
+ * ComponentName.flattenToString() produces "pkg/pkg.ServiceName" — the exact
+ * format the system stores. ComponentName.unflattenFromString() reverses it.
  */
 object AccessibilityManager {
 
     private const val TAG = "AccessibilityManager"
-    private const val SETTINGS_KEY = Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
-    private const val SHELL_TIMEOUT_SECONDS = 10L
-
-    /** Serializes every read-modify-write so toggles can't race each other. */
-    private val lock = Mutex()
+    private const val KEY = Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
 
     /**
-     * Set just before a shell write and cleared by the daemon's ContentObserver
-     * when it fires for that write, so the daemon never re-restores the services
-     * it (or the user, via this object) just wrote. Mirrors the reference app's
-     * isSelfModification flag.
+     * Set just before a write and cleared by the daemon's ContentObserver
+     * when it fires for that write, so the daemon never re-restores the
+     * services it just wrote. Mirrors the reference app's isSelfModification.
      */
     @Volatile
     private var selfWritePending = false
@@ -52,147 +38,111 @@ object AccessibilityManager {
         selfWritePending = false
     }
 
-    /** Current enabled services, read through the Shizuku shell (unfiltered). */
-    suspend fun getEnabledServices(context: Context): Set<String> = lock.withLock {
-        readEnabledServices(context)
+    // -----------------------------------------------------------------
+    // Reads
+    // -----------------------------------------------------------------
+
+    /**
+     * Returns the set of enabled service ComponentNames, parsed from
+     * [Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES]. Uses the app's
+     * own ContentResolver — NOT filtered by package visibility, because
+     * we're reading a settings string, not querying PackageManager.
+     */
+    fun getEnabledServices(context: Context): Set<ComponentName> {
+        val raw = Settings.Secure.getString(context.contentResolver, KEY) ?: return emptySet()
+        if (raw.isBlank()) return emptySet()
+        return raw.split(':')
+            .filter { it.isNotBlank() }
+            .mapNotNull { ComponentName.unflattenFromString(it) }
+            .toSet()
     }
 
-    /** Enable a service, atomically: read fresh → add → write. */
-    suspend fun enableService(context: Context, serviceId: String): Boolean = lock.withLock {
-        val enabled = readEnabledServices(context).toMutableSet()
-        if (!enabled.add(serviceId)) return@withLock true
-        writeEnabledServices(context, enabled)
+    /** Returns true if [serviceId] (flattenToString format) is currently enabled. */
+    fun isServiceEnabled(context: Context, serviceId: String): Boolean {
+        val target = ComponentName.unflattenFromString(serviceId) ?: return false
+        return getEnabledServices(context).contains(target)
     }
 
-    /** Disable a service, atomically: read fresh → remove → write. */
-    suspend fun disableService(context: Context, serviceId: String): Boolean = lock.withLock {
-        val enabled = readEnabledServices(context).toMutableSet()
-        if (!enabled.remove(serviceId)) return@withLock true
-        writeEnabledServices(context, enabled)
+    // -----------------------------------------------------------------
+    // Writes (synchronous, atomic)
+    // -----------------------------------------------------------------
+
+    /**
+     * Enable [serviceId] (flattenToString format). Atomically reads the
+     * current list, adds the service, and writes back.
+     */
+    fun enableService(context: Context, serviceId: String): Boolean {
+        val cn = ComponentName.unflattenFromString(serviceId) ?: run {
+            Log.w(TAG, "Cannot parse service id: $serviceId")
+            return false
+        }
+        val enabled = getEnabledServices(context).toMutableSet()
+        if (!enabled.add(cn)) return true // already enabled
+        return writeServices(context, enabled)
+    }
+
+    /**
+     * Disable [serviceId] (flattenToString format). Atomically reads the
+     * current list, removes the service, and writes back.
+     */
+    fun disableService(context: Context, serviceId: String): Boolean {
+        val cn = ComponentName.unflattenFromString(serviceId) ?: run {
+            Log.w(TAG, "Cannot parse service id: $serviceId")
+            return false
+        }
+        val enabled = getEnabledServices(context).toMutableSet()
+        if (!enabled.remove(cn)) return true // already disabled
+        return writeServices(context, enabled)
     }
 
     /**
      * Re-enable every pinned-but-missing service. Returns the list that was
      * restored (empty if nothing needed restoring or the write failed).
      */
-    suspend fun restorePinnedServices(context: Context): List<String> = lock.withLock {
-        val pinned = AccessibilityKeepAliveStore.getKeepAliveIds()
-        if (pinned.isEmpty()) return@withLock emptyList()
+    fun restorePinnedServices(context: Context): List<String> {
+        val pinnedRaw = AccessibilityKeepAliveStore.getKeepAliveIds()
+        if (pinnedRaw.isEmpty()) return emptyList()
 
-        val enabled = readEnabledServices(context).toMutableSet()
+        val pinned = pinnedRaw.mapNotNull { ComponentName.unflattenFromString(it) }
+        if (pinned.isEmpty()) return emptyList()
+
+        val enabled = getEnabledServices(context).toMutableSet()
         val missing = pinned.filter { it !in enabled }
-        if (missing.isEmpty()) return@withLock emptyList()
+        if (missing.isEmpty()) return emptyList()
 
         enabled.addAll(missing)
-        if (writeEnabledServices(context, enabled)) {
-            logd("Restored pinned accessibility services: $missing")
-            return@withLock missing
+        if (writeServices(context, enabled)) {
+            Log.d(TAG, "Restored pinned accessibility services: $missing")
+            return missing.map { it.flattenToString() }
         }
-        logw("Failed to restore pinned accessibility services: $missing")
-        emptyList()
+        Log.w(TAG, "Failed to restore pinned accessibility services: $missing")
+        return emptyList()
     }
 
-    // ---------------------------------------------------------------------
-    // Shell plumbing
-    // ---------------------------------------------------------------------
-
-    /** Reads the raw enabled list via `settings get secure` (never filtered). */
-    private suspend fun readEnabledServices(context: Context): Set<String> {
-        val result = runShizukuShell("settings get secure $SETTINGS_KEY") ?: return emptySet()
-        val value = result.trim()
-        if (value.isEmpty() || value == "null") return emptySet()
-        return value.split(':').filter { it.isNotEmpty() }.toSet()
-    }
-
-    /** Writes the full enabled list via `settings put secure`. */
-    private suspend fun writeEnabledServices(context: Context, services: Set<String>): Boolean {
-        if (!Shizuku.pingBinder()) {
-            logw("Cannot write accessibility services: Shizuku not running")
-            return false
-        }
-        val value = services.sorted().joinToString(":")
-        val cmd = "settings put secure $SETTINGS_KEY ${shellQuote(value)}"
-        selfWritePending = true
-        val result = runShizukuShell(cmd)
-        if (result == null) {
-            selfWritePending = false
-            return false
-        }
-        logd("Wrote enabled accessibility services (${services.size}): $cmd")
-        return true
-    }
+    // -----------------------------------------------------------------
+    // Low-level write
+    // -----------------------------------------------------------------
 
     /**
-     * Runs a shell command through Shizuku and returns its stdout, or null on
-     * failure. Command is executed via `sh -c` so quoting works as expected.
+     * Writes the full set of enabled services to Settings.Secure.
+     * Sets [selfWritePending] so the daemon's ContentObserver knows to
+     * ignore the resulting change notification.
      */
-    private suspend fun runShizukuShell(cmd: String): String? = withContext(Dispatchers.IO) {
-        if (!Shizuku.pingBinder()) {
-            logw("Cannot run shell command: Shizuku not running")
-            return@withContext null
-        }
-        try {
-            val binder = Shizuku.getBinder() ?: return@withContext null
-            val service = IShizukuService.Stub.asInterface(binder)
-            val remote = service.newProcess(arrayOf("sh", "-c", cmd), null, null)
-
-            val stdoutPfd = remote.getInputStream()
-            val stderrPfd = remote.getErrorStream()
-
-            var stdoutText = ""
-            var stderrText = ""
-            val stdoutThread = Thread {
-                try {
-                    stdoutText = readStream(stdoutPfd)
-                } catch (ignore: Exception) {
-                }
-            }
-            val stderrThread = Thread {
-                try {
-                    stderrText = readStream(stderrPfd)
-                } catch (ignore: Exception) {
-                }
-            }
-            stdoutThread.start()
-            stderrThread.start()
-
-            val finished = remote.waitForTimeout(SHELL_TIMEOUT_SECONDS, TimeUnit.SECONDS.name)
-            val exitCode = if (finished) {
-                remote.exitValue()
-            } else {
-                logw("Shell command timed out: $cmd")
-                remote.destroy()
-                -1
-            }
-            stdoutThread.join(2_000)
-            stderrThread.join(2_000)
-
-            if (exitCode != 0) {
-                logw("Shell command failed (exit $exitCode): $cmd ${stderrText.take(300)}")
-                return@withContext null
-            }
-            stdoutText.trim()
+    private fun writeServices(context: Context, services: Set<ComponentName>): Boolean {
+        val value = services.joinToString(":") { it.flattenToString() }
+        selfWritePending = true
+        val ok = try {
+            Settings.Secure.putString(context.contentResolver, KEY, value)
         } catch (e: Exception) {
-            logw("Shell command exception: ${e.message}")
-            null
+            Log.w(TAG, "Failed to write enabled accessibility services: ${e.message}")
+            selfWritePending = false
+            false
         }
-    }
-
-    /** Reads the full stdout of a ParcelFileDescriptor. */
-    private fun readStream(pfd: ParcelFileDescriptor): String {
-        return ParcelFileDescriptor.AutoCloseInputStream(pfd).reader(Charsets.UTF_8).use { reader ->
-            val buffer = CharArray(8192)
-            val sb = StringBuilder()
-            while (true) {
-                val read = reader.read(buffer)
-                if (read <= 0) break
-                sb.append(buffer, 0, read)
-                if (sb.length > 64 * 1024) break
-            }
-            sb.toString()
+        if (ok) {
+            Log.d(TAG, "Wrote enabled accessibility services (${services.size})")
+        } else {
+            selfWritePending = false
         }
+        return ok
     }
-
-    /** Single-quotes a value for safe use inside `sh -c`. */
-    private fun shellQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"
 }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
@@ -1,0 +1,154 @@
+package moe.shizuku.manager.accessibility
+
+import android.content.ComponentName
+import android.content.Context
+import android.os.ParcelFileDescriptor
+import android.provider.Settings
+import android.util.Log
+import moe.shizuku.manager.ktx.logd
+import moe.shizuku.manager.ktx.logi
+import moe.shizuku.manager.ktx.logw
+import moe.shizuku.server.IShizukuService
+import rikka.shizuku.Shizuku
+import java.util.concurrent.TimeUnit
+
+/**
+ * Core controller for the Accessibility Manager feature.
+ *
+ * The enabled-services list lives in
+ * [Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES] as a colon-separated
+ * string of flattened [ComponentName]s. Reading it requires no permission;
+ * writing it requires WRITE_SECURE_SETTINGS. Since Shevery already owns the
+ * Shizuku shell (which runs with that permission), writes go through a
+ * Shizuku `settings put secure` command instead of requesting the permission
+ * for the app process itself.
+ */
+object AccessibilityManager {
+
+    private const val TAG = "AccessibilityManager"
+    private const val SETTINGS_KEY = Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+    private const val SHELL_TIMEOUT_SECONDS = 10L
+
+    /**
+     * Read the set of currently enabled accessibility services.
+     * Safe to call from the app process (readable without permission).
+     */
+    fun getEnabledServices(context: Context): Set<String> {
+        val raw = Settings.Secure.getString(context.contentResolver, SETTINGS_KEY) ?: return emptySet()
+        return raw.split(":").filter { it.isNotBlank() }.toSet()
+    }
+
+    /**
+     * Whether a specific service (flattened ComponentName string) is enabled.
+     */
+    fun isServiceEnabled(context: Context, serviceId: String): Boolean {
+        return getEnabledServices(context).contains(serviceId)
+    }
+
+    /**
+     * Enable a service, preserving all currently enabled services.
+     *
+     * @return true if the write succeeded
+     */
+    suspend fun enableService(context: Context, serviceId: String): Boolean {
+        val enabled = getEnabledServices(context).toMutableSet()
+        if (!enabled.add(serviceId)) return true
+        return writeEnabledServices(context, enabled)
+    }
+
+    /**
+     * Disable a service, preserving all other currently enabled services.
+     *
+     * @return true if the write succeeded
+     */
+    suspend fun disableService(context: Context, serviceId: String): Boolean {
+        val enabled = getEnabledServices(context).toMutableSet()
+        if (!enabled.remove(serviceId)) return true
+        return writeEnabledServices(context, enabled)
+    }
+
+    /**
+     * Overwrite the enabled-services list with exactly [services].
+     *
+     * @return true if the write succeeded
+     */
+    suspend fun writeEnabledServices(context: Context, services: Set<String>): Boolean {
+        if (!Shizuku.pingBinder()) {
+            logw("Cannot write accessibility services: Shizuku not running")
+            return false
+        }
+        val newValue = services.joinToString(":")
+        val cmd = "settings put secure $SETTINGS_KEY ${shellQuote(newValue)}"
+        val (exitCode, stderr) = runShizukuShell(cmd)
+        if (exitCode == 0) {
+            logi("Enabled accessibility services updated: $newValue")
+            return true
+        }
+        Log.e(TAG, "Failed to write accessibility services (exit $exitCode): $stderr")
+        return false
+    }
+
+    /**
+     * Ensure all pinned services are present in the enabled list.
+     * Returns the list of services that were re-enabled, if any.
+     */
+    suspend fun restorePinnedServices(context: Context): List<String> {
+        val pinned = AccessibilityKeepAliveStore.getKeepAliveIds()
+        if (pinned.isEmpty()) return emptyList()
+
+        val enabled = getEnabledServices(context).toMutableSet()
+        val missing = pinned.filter { it !in enabled }
+        if (missing.isEmpty()) return emptyList()
+
+        enabled.addAll(missing)
+        if (writeEnabledServices(context, enabled)) {
+            logd("Restored pinned accessibility services: $missing")
+            return missing
+        }
+        return emptyList()
+    }
+
+    private suspend fun runShizukuShell(cmd: String): Pair<Int, String> {
+        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            try {
+                val binder = Shizuku.getBinder()
+                    ?: return@withContext -1 to "No binder"
+                val service = IShizukuService.Stub.asInterface(binder)
+                val process = service.newProcess(arrayOf("sh", "-c", cmd), null, null)
+
+                val stderrPfd = process.getErrorStream()
+                val stderrThread = Thread {
+                    try {
+                        readStream(stderrPfd)
+                    } catch (ignore: Exception) {
+                        ""
+                    }
+                }
+                stderrThread.start()
+
+                val finished = process.waitForTimeout(SHELL_TIMEOUT_SECONDS, TimeUnit.SECONDS.name)
+                val exitCode = if (finished) {
+                    process.exitValue()
+                } else {
+                    process.destroy()
+                    124
+                }
+                stderrThread.join(1000)
+                exitCode to ""
+            } catch (e: Exception) {
+                Log.e(TAG, "Shizuku shell failed", e)
+                -1 to (e.message ?: e.toString())
+            }
+        }
+    }
+
+    private fun readStream(pfd: ParcelFileDescriptor): String {
+        return ParcelFileDescriptor.AutoCloseInputStream(pfd).reader(Charsets.UTF_8).use { reader ->
+            reader.readText().trim()
+        }
+    }
+
+    private fun shellQuote(value: String): String {
+        return "'" + value.replace("'", "'\\''") + "'"
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
@@ -30,6 +30,20 @@ object AccessibilityManager {
     private const val SHELL_TIMEOUT_SECONDS = 10L
 
     /**
+     * Set when this app writes the enabled-services list, so the daemon's
+     * ContentObserver can ignore its own change and avoid a restore loop.
+     * Mirrors the reference app's isSelfModification flag.
+     */
+    @Volatile
+    private var selfWritePending = false
+
+    fun wasSelfWrite(): Boolean = selfWritePending
+
+    fun clearSelfWrite() {
+        selfWritePending = false
+    }
+
+    /**
      * Read the set of currently enabled accessibility services.
      * Safe to call from the app process (readable without permission).
      */
@@ -79,11 +93,13 @@ object AccessibilityManager {
         }
         val newValue = services.joinToString(":")
         val cmd = "settings put secure $SETTINGS_KEY ${shellQuote(newValue)}"
+        selfWritePending = true
         val (exitCode, stderr) = runShizukuShell(cmd)
         if (exitCode == 0) {
             logi("Enabled accessibility services updated: $newValue")
             return true
         }
+        selfWritePending = false
         Log.e(TAG, "Failed to write accessibility services (exit $exitCode): $stderr")
         return false
     }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManager.kt
@@ -1,27 +1,32 @@
 package moe.shizuku.manager.accessibility
 
-import android.content.ComponentName
 import android.content.Context
 import android.os.ParcelFileDescriptor
 import android.provider.Settings
-import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import moe.shizuku.manager.ktx.logd
-import moe.shizuku.manager.ktx.logi
 import moe.shizuku.manager.ktx.logw
 import moe.shizuku.server.IShizukuService
 import rikka.shizuku.Shizuku
+import java.io.BufferedReader
 import java.util.concurrent.TimeUnit
 
 /**
- * Core controller for the Accessibility Manager feature.
+ * Core controller for accessibility service management.
  *
- * The enabled-services list lives in
- * [Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES] as a colon-separated
- * string of flattened [ComponentName]s. Reading it requires no permission;
- * writing it requires WRITE_SECURE_SETTINGS. Since Shevery already owns the
- * Shizuku shell (which runs with that permission), writes go through a
- * Shizuku `settings put secure` command instead of requesting the permission
- * for the app process itself.
+ * All reads and writes go through the Shizuku shell:
+ *  - `settings get secure enabled_accessibility_services` — ground truth, never
+ *    filtered by Android 11+ package visibility (an app-process read of
+ *    [Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES] IS filtered, which is why
+ *    states appeared wrong for most services).
+ *  - `settings put secure ...` — shell owns WRITE_SECURE_SETTINGS.
+ *
+ * Every read-modify-write cycle is serialized by [lock] so rapid toggles can
+ * never clobber each other (a previous toggle must not be reverted by a
+ * concurrent one).
  */
 object AccessibilityManager {
 
@@ -29,142 +34,165 @@ object AccessibilityManager {
     private const val SETTINGS_KEY = Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
     private const val SHELL_TIMEOUT_SECONDS = 10L
 
+    /** Serializes every read-modify-write so toggles can't race each other. */
+    private val lock = Mutex()
+
     /**
-     * Set when this app writes the enabled-services list, so the daemon's
-     * ContentObserver can ignore its own change and avoid a restore loop.
-     * Mirrors the reference app's isSelfModification flag.
+     * Set just before a shell write and cleared by the daemon's ContentObserver
+     * when it fires for that write, so the daemon never re-restores the services
+     * it (or the user, via this object) just wrote. Mirrors the reference app's
+     * isSelfModification flag.
      */
     @Volatile
     private var selfWritePending = false
 
-    fun wasSelfWrite(): Boolean = selfWritePending
+    fun isSelfWrite(): Boolean = selfWritePending
 
     fun clearSelfWrite() {
         selfWritePending = false
     }
 
-    /**
-     * Read the set of currently enabled accessibility services.
-     * Safe to call from the app process (readable without permission).
-     */
-    fun getEnabledServices(context: Context): Set<String> {
-        val raw = Settings.Secure.getString(context.contentResolver, SETTINGS_KEY) ?: return emptySet()
-        return raw.split(":").filter { it.isNotBlank() }.toSet()
+    /** Current enabled services, read through the Shizuku shell (unfiltered). */
+    suspend fun getEnabledServices(context: Context): Set<String> = lock.withLock {
+        readEnabledServices(context)
+    }
+
+    /** Enable a service, atomically: read fresh → add → write. */
+    suspend fun enableService(context: Context, serviceId: String): Boolean = lock.withLock {
+        val enabled = readEnabledServices(context).toMutableSet()
+        if (!enabled.add(serviceId)) return@withLock true
+        writeEnabledServices(context, enabled)
+    }
+
+    /** Disable a service, atomically: read fresh → remove → write. */
+    suspend fun disableService(context: Context, serviceId: String): Boolean = lock.withLock {
+        val enabled = readEnabledServices(context).toMutableSet()
+        if (!enabled.remove(serviceId)) return@withLock true
+        writeEnabledServices(context, enabled)
     }
 
     /**
-     * Whether a specific service (flattened ComponentName string) is enabled.
+     * Re-enable every pinned-but-missing service. Returns the list that was
+     * restored (empty if nothing needed restoring or the write failed).
      */
-    fun isServiceEnabled(context: Context, serviceId: String): Boolean {
-        return getEnabledServices(context).contains(serviceId)
-    }
-
-    /**
-     * Enable a service, preserving all currently enabled services.
-     *
-     * @return true if the write succeeded
-     */
-    suspend fun enableService(context: Context, serviceId: String): Boolean {
-        val enabled = getEnabledServices(context).toMutableSet()
-        if (!enabled.add(serviceId)) return true
-        return writeEnabledServices(context, enabled)
-    }
-
-    /**
-     * Disable a service, preserving all other currently enabled services.
-     *
-     * @return true if the write succeeded
-     */
-    suspend fun disableService(context: Context, serviceId: String): Boolean {
-        val enabled = getEnabledServices(context).toMutableSet()
-        if (!enabled.remove(serviceId)) return true
-        return writeEnabledServices(context, enabled)
-    }
-
-    /**
-     * Overwrite the enabled-services list with exactly [services].
-     *
-     * @return true if the write succeeded
-     */
-    suspend fun writeEnabledServices(context: Context, services: Set<String>): Boolean {
-        if (!Shizuku.pingBinder()) {
-            logw("Cannot write accessibility services: Shizuku not running")
-            return false
-        }
-        val newValue = services.joinToString(":")
-        val cmd = "settings put secure $SETTINGS_KEY ${shellQuote(newValue)}"
-        selfWritePending = true
-        val (exitCode, stderr) = runShizukuShell(cmd)
-        if (exitCode == 0) {
-            logi("Enabled accessibility services updated: $newValue")
-            return true
-        }
-        selfWritePending = false
-        Log.e(TAG, "Failed to write accessibility services (exit $exitCode): $stderr")
-        return false
-    }
-
-    /**
-     * Ensure all pinned services are present in the enabled list.
-     * Returns the list of services that were re-enabled, if any.
-     */
-    suspend fun restorePinnedServices(context: Context): List<String> {
+    suspend fun restorePinnedServices(context: Context): List<String> = lock.withLock {
         val pinned = AccessibilityKeepAliveStore.getKeepAliveIds()
-        if (pinned.isEmpty()) return emptyList()
+        if (pinned.isEmpty()) return@withLock emptyList()
 
-        val enabled = getEnabledServices(context).toMutableSet()
+        val enabled = readEnabledServices(context).toMutableSet()
         val missing = pinned.filter { it !in enabled }
-        if (missing.isEmpty()) return emptyList()
+        if (missing.isEmpty()) return@withLock emptyList()
 
         enabled.addAll(missing)
         if (writeEnabledServices(context, enabled)) {
             logd("Restored pinned accessibility services: $missing")
-            return missing
+            return@withLock missing
         }
-        return emptyList()
+        logw("Failed to restore pinned accessibility services: $missing")
+        emptyList()
     }
 
-    private suspend fun runShizukuShell(cmd: String): Pair<Int, String> {
-        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            try {
-                val binder = Shizuku.getBinder()
-                    ?: return@withContext -1 to "No binder"
-                val service = IShizukuService.Stub.asInterface(binder)
-                val process = service.newProcess(arrayOf("sh", "-c", cmd), null, null)
+    // ---------------------------------------------------------------------
+    // Shell plumbing
+    // ---------------------------------------------------------------------
 
-                val stderrPfd = process.getErrorStream()
-                val stderrThread = Thread {
-                    try {
-                        readStream(stderrPfd)
-                    } catch (ignore: Exception) {
-                        ""
-                    }
-                }
-                stderrThread.start()
+    /** Reads the raw enabled list via `settings get secure` (never filtered). */
+    private suspend fun readEnabledServices(context: Context): Set<String> {
+        val result = runShizukuShell("settings get secure $SETTINGS_KEY") ?: return emptySet()
+        val value = result.trim()
+        if (value.isEmpty() || value == "null") return emptySet()
+        return value.split(':').filter { it.isNotEmpty() }.toSet()
+    }
 
-                val finished = process.waitForTimeout(SHELL_TIMEOUT_SECONDS, TimeUnit.SECONDS.name)
-                val exitCode = if (finished) {
-                    process.exitValue()
-                } else {
-                    process.destroy()
-                    124
+    /** Writes the full enabled list via `settings put secure`. */
+    private suspend fun writeEnabledServices(context: Context, services: Set<String>): Boolean {
+        if (!Shizuku.pingBinder()) {
+            logw("Cannot write accessibility services: Shizuku not running")
+            return false
+        }
+        val value = services.sorted().joinToString(":")
+        val cmd = "settings put secure $SETTINGS_KEY ${shellQuote(value)}"
+        selfWritePending = true
+        val result = runShizukuShell(cmd)
+        if (result == null) {
+            selfWritePending = false
+            return false
+        }
+        logd("Wrote enabled accessibility services (${services.size}): $cmd")
+        return true
+    }
+
+    /**
+     * Runs a shell command through Shizuku and returns its stdout, or null on
+     * failure. Command is executed via `sh -c` so quoting works as expected.
+     */
+    private suspend fun runShizukuShell(cmd: String): String? = withContext(Dispatchers.IO) {
+        if (!Shizuku.pingBinder()) {
+            logw("Cannot run shell command: Shizuku not running")
+            return@withContext null
+        }
+        try {
+            val binder = Shizuku.getBinder() ?: return@withContext null
+            val service = IShizukuService.Stub.asInterface(binder)
+            val remote = service.newProcess(arrayOf("sh", "-c", cmd), null, null)
+
+            val stdoutPfd = remote.getInputStream()
+            val stderrPfd = remote.getErrorStream()
+
+            var stdoutText = ""
+            var stderrText = ""
+            val stdoutThread = Thread {
+                try {
+                    stdoutText = readStream(stdoutPfd)
+                } catch (ignore: Exception) {
                 }
-                stderrThread.join(1000)
-                exitCode to ""
-            } catch (e: Exception) {
-                Log.e(TAG, "Shizuku shell failed", e)
-                -1 to (e.message ?: e.toString())
             }
+            val stderrThread = Thread {
+                try {
+                    stderrText = readStream(stderrPfd)
+                } catch (ignore: Exception) {
+                }
+            }
+            stdoutThread.start()
+            stderrThread.start()
+
+            val finished = remote.waitForTimeout(SHELL_TIMEOUT_SECONDS, TimeUnit.SECONDS.name)
+            val exitCode = if (finished) {
+                remote.exitValue()
+            } else {
+                logw("Shell command timed out: $cmd")
+                remote.destroy()
+                -1
+            }
+            stdoutThread.join(2_000)
+            stderrThread.join(2_000)
+
+            if (exitCode != 0) {
+                logw("Shell command failed (exit $exitCode): $cmd ${stderrText.take(300)}")
+                return@withContext null
+            }
+            stdoutText.trim()
+        } catch (e: Exception) {
+            logw("Shell command exception: ${e.message}")
+            null
         }
     }
 
+    /** Reads the full stdout of a ParcelFileDescriptor. */
     private fun readStream(pfd: ParcelFileDescriptor): String {
         return ParcelFileDescriptor.AutoCloseInputStream(pfd).reader(Charsets.UTF_8).use { reader ->
-            reader.readText().trim()
+            val buffer = CharArray(8192)
+            val sb = StringBuilder()
+            while (true) {
+                val read = reader.read(buffer)
+                if (read <= 0) break
+                sb.append(buffer, 0, read)
+                if (sb.length > 64 * 1024) break
+            }
+            sb.toString()
         }
     }
 
-    private fun shellQuote(value: String): String {
-        return "'" + value.replace("'", "'\\''") + "'"
-    }
+    /** Single-quotes a value for safe use inside `sh -c`. */
+    private fun shellQuote(value: String): String = "'" + value.replace("'", "'\\''") + "'"
 }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
@@ -77,13 +77,13 @@ class AccessibilityManagerActivity : AppActivity() {
 
         setContent {
             val context = LocalContext.current
-            val services = remember(tick) { loadServices(context) }
+            val pinnedIds = remember(tick) { AccessibilityKeepAliveStore.getKeepAliveIds() }
+            val services = remember(tick) { loadServices(context, pinnedIds) }
             val enabledIds = remember(tick) {
                 AccessibilityManager.getEnabledServices(context)
                     .map { it.flattenToString() }
                     .toSet()
             }
-            val pinnedIds = remember(tick) { AccessibilityKeepAliveStore.getKeepAliveIds() }
             val keepAliveEnabled = remember(tick) { AccessibilityKeepAliveStore.isKeepAliveEnabled() }
             val autoBoot = remember(tick) { AccessibilityKeepAliveStore.isAutoBootEnabled() }
             val shizukuRunning = remember(tick) { Shizuku.pingBinder() }
@@ -212,7 +212,7 @@ class AccessibilityManagerActivity : AppActivity() {
         super.onDestroy()
     }
 
-    private fun loadServices(context: Context): List<AccessibilityServiceEntry> {
+    private fun loadServices(context: Context, pinnedIds: Set<String>): List<AccessibilityServiceEntry> {
         val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as SystemAccessibilityManager?
             ?: return emptyList()
         val pm = context.packageManager
@@ -242,7 +242,8 @@ class AccessibilityManagerActivity : AppActivity() {
                 null
             }
         }.sortedWith(
-            compareBy<AccessibilityServiceEntry> { it.label.lowercase() }
+            compareBy<AccessibilityServiceEntry> { it.id !in pinnedIds }
+                .thenBy { it.label.lowercase() }
         )
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
@@ -160,6 +160,12 @@ class AccessibilityManagerActivity : AppActivity() {
                                         canWrite = shizukuRunning,
                                         onToggle = { target ->
                                             scope.launch {
+                                                // Unpin a service when the user disables it, so the
+                                                // keep-alive daemon doesn't immediately re-enable it
+                                                // (toggle "fight"). Mirrors the reference app's behavior.
+                                                if (!target && AccessibilityKeepAliveStore.isPinned(service.id)) {
+                                                    AccessibilityKeepAliveStore.removePinned(service.id)
+                                                }
                                                 val ok = if (target) {
                                                     AccessibilityManager.enableService(context, service.id)
                                                 } else {

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -80,7 +81,9 @@ class AccessibilityManagerActivity : AppActivity() {
         setContent {
             val context = LocalContext.current
             val services = remember(tick) { loadServices(context) }
-            val enabledIds = remember(tick) { AccessibilityManager.getEnabledServices(context) }
+            val enabledIds by produceState(initialValue = emptySet<String>(), key1 = tick, context) {
+                value = AccessibilityManager.getEnabledServices(context)
+            }
             val pinnedIds = remember(tick) { AccessibilityKeepAliveStore.getKeepAliveIds() }
             val keepAliveEnabled = remember(tick) { AccessibilityKeepAliveStore.isKeepAliveEnabled() }
             val autoBoot = remember(tick) { AccessibilityKeepAliveStore.isAutoBootEnabled() }

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
@@ -1,0 +1,318 @@
+@file:OptIn(
+    androidx.compose.material3.ExperimentalMaterial3Api::class,
+    androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class
+)
+
+package moe.shizuku.manager.accessibility
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.accessibility.AccessibilityManager as SystemAccessibilityManager
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material.icons.rounded.LockOpen
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.R
+import moe.shizuku.manager.app.AppActivity
+import moe.shizuku.manager.ktx.loge
+import moe.shizuku.manager.ui.compose.ExpressiveSwitch
+import moe.shizuku.manager.ui.compose.GroupDivider
+import moe.shizuku.manager.ui.compose.SettingsGroup
+import moe.shizuku.manager.ui.compose.ShizukuExpressiveTheme
+import moe.shizuku.manager.ui.compose.ShizukuLazyScaffold
+import moe.shizuku.manager.ui.compose.SwitchSettingsRow
+import rikka.shizuku.Shizuku
+
+/**
+ * Accessibility Manager screen.
+ *
+ * Lists every installed accessibility service with a live enable/disable
+ * switch and a pin (keep-alive) toggle. Toggles are written through the
+ * Shizuku shell; pinned services are kept alive by [AccessibilityDaemonService].
+ */
+class AccessibilityManagerActivity : AppActivity() {
+
+    private var tick by mutableIntStateOf(0)
+
+    private val binderDeadListener = Shizuku.OnBinderDeadListener {
+        if (!isFinishing) {
+            tick++
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        Shizuku.addBinderDeadListener(binderDeadListener)
+
+        setContent {
+            val context = LocalContext.current
+            val services = remember(tick) { loadServices(context) }
+            val enabledIds = remember(tick) { AccessibilityManager.getEnabledServices(context) }
+            val pinnedIds = remember(tick) { AccessibilityKeepAliveStore.getKeepAliveIds() }
+            val keepAliveEnabled = remember(tick) { AccessibilityKeepAliveStore.isKeepAliveEnabled() }
+            val autoBoot = remember(tick) { AccessibilityKeepAliveStore.isAutoBootEnabled() }
+            val shizukuRunning = remember(tick) { Shizuku.pingBinder() }
+            val scope = rememberCoroutineScope()
+
+            ShizukuExpressiveTheme {
+                ShizukuLazyScaffold(
+                    title = stringResource(R.string.accessibility_manager_title),
+                    onNavigateUp = { finish() }
+                ) {
+                    item {
+                        SettingsGroup(title = stringResource(R.string.accessibility_manager_keep_alive_group)) {
+                            SwitchSettingsRow(
+                                icon = R.drawable.ic_system_icon,
+                                title = stringResource(R.string.accessibility_manager_keep_alive_title),
+                                summary = stringResource(R.string.accessibility_manager_keep_alive_summary),
+                                checked = keepAliveEnabled,
+                                onCheckedChange = { enabled ->
+                                    AccessibilityKeepAliveStore.setKeepAliveEnabled(enabled)
+                                    tick++
+                                    AccessibilityDaemonService.reconcile(this@AccessibilityManagerActivity)
+                                }
+                            )
+                            GroupDivider()
+                            SwitchSettingsRow(
+                                icon = R.drawable.ic_server_restart,
+                                title = stringResource(R.string.accessibility_manager_auto_boot_title),
+                                summary = stringResource(R.string.accessibility_manager_auto_boot_summary),
+                                checked = autoBoot,
+                                enabled = keepAliveEnabled,
+                                onCheckedChange = { enabled ->
+                                    AccessibilityKeepAliveStore.setAutoBootEnabled(enabled)
+                                    tick++
+                                }
+                            )
+                        }
+                    }
+
+                    item {
+                        if (!shizukuRunning) {
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = MaterialTheme.shapes.extraLarge,
+                                color = MaterialTheme.colorScheme.errorContainer
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.accessibility_manager_shizuku_required),
+                                    modifier = Modifier.padding(16.dp),
+                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        }
+                    }
+
+                    item {
+                        SettingsGroup(
+                            title = stringResource(
+                                R.string.accessibility_manager_services_group,
+                                services.size
+                            )
+                        ) {
+                            if (services.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.accessibility_manager_services_empty),
+                                    modifier = Modifier.padding(16.dp),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            } else {
+                                services.forEachIndexed { index, service ->
+                                    ServiceRow(
+                                        service = service,
+                                        enabled = enabledIds.contains(service.id),
+                                        pinned = pinnedIds.contains(service.id),
+                                        canWrite = shizukuRunning,
+                                        onToggle = { target ->
+                                            scope.launch {
+                                                val ok = if (target) {
+                                                    AccessibilityManager.enableService(context, service.id)
+                                                } else {
+                                                    AccessibilityManager.disableService(context, service.id)
+                                                }
+                                                if (!ok) {
+                                                    MaterialAlertDialogBuilder(this@AccessibilityManagerActivity)
+                                                        .setMessage(R.string.accessibility_manager_write_failed)
+                                                        .setPositiveButton(android.R.string.ok, null)
+                                                        .show()
+                                                }
+                                                tick++
+                                            }
+                                        },
+                                        onPin = {
+                                            if (AccessibilityKeepAliveStore.isPinned(service.id)) {
+                                                AccessibilityKeepAliveStore.removePinned(service.id)
+                                            } else {
+                                                AccessibilityKeepAliveStore.addPinned(service.id)
+                                            }
+                                            tick++
+                                        },
+                                        onDetails = {
+                                            MaterialAlertDialogBuilder(this@AccessibilityManagerActivity)
+                                                .setTitle(service.label)
+                                                .setMessage(service.description)
+                                                .setPositiveButton(android.R.string.ok, null)
+                                                .show()
+                                        }
+                                    )
+                                    if (index < services.lastIndex) {
+                                        HorizontalDivider()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        Shizuku.removeBinderDeadListener(binderDeadListener)
+        super.onDestroy()
+    }
+
+    private fun loadServices(context: Context): List<AccessibilityServiceEntry> {
+        val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as SystemAccessibilityManager?
+            ?: return emptyList()
+        val pm = context.packageManager
+        return am.getInstalledAccessibilityServiceList().mapNotNull { info ->
+            try {
+                val componentName = info.resolveInfo.serviceInfo.run {
+                    android.content.ComponentName(packageName, name)
+                }
+                val appInfo = pm.getApplicationInfo(componentName.packageName, 0)
+                val label = info.resolveInfo.loadLabel(pm)?.toString()
+                    ?: pm.getApplicationLabel(appInfo).toString()
+                val description = info.loadDescription(pm)?.toString()
+                    ?: context.getString(R.string.accessibility_manager_service_no_description)
+                val icon = pm.getApplicationIcon(componentName.packageName)
+                    .toBitmap(64, 64)
+                    .asImageBitmap()
+                AccessibilityServiceEntry(
+                    id = componentName.flattenToString(),
+                    label = label,
+                    description = description,
+                    icon = icon
+                )
+            } catch (e: PackageManager.NameNotFoundException) {
+                null
+            } catch (e: Exception) {
+                loge("Failed to load accessibility service", e)
+                null
+            }
+        }.sortedWith(
+            compareBy<AccessibilityServiceEntry> { it.label.lowercase() }
+        )
+    }
+}
+
+private data class AccessibilityServiceEntry(
+    val id: String,
+    val label: String,
+    val description: String,
+    val icon: androidx.compose.ui.graphics.ImageBitmap
+)
+
+@Composable
+private fun ServiceRow(
+    service: AccessibilityServiceEntry,
+    enabled: Boolean,
+    pinned: Boolean,
+    canWrite: Boolean,
+    onToggle: (Boolean) -> Unit,
+    onPin: () -> Unit,
+    onDetails: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = true, onClick = onDetails)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Image(
+            bitmap = service.icon,
+            contentDescription = null,
+            modifier = Modifier.size(36.dp)
+        )
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = service.label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = service.id,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        if (enabled) {
+            IconButton(onClick = onPin) {
+                Icon(
+                    imageVector = if (pinned) Icons.Rounded.Lock else Icons.Rounded.LockOpen,
+                    contentDescription = stringResource(
+                        if (pinned) {
+                            R.string.accessibility_manager_unpin
+                        } else {
+                            R.string.accessibility_manager_pin
+                        }
+                    ),
+                    tint = if (pinned) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                )
+            }
+        }
+        ExpressiveSwitch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            enabled = canWrite
+        )
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/accessibility/AccessibilityManagerActivity.kt
@@ -30,9 +30,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,7 +42,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.coroutines.launch
 import moe.shizuku.manager.R
 import moe.shizuku.manager.app.AppActivity
 import moe.shizuku.manager.ktx.loge
@@ -81,14 +78,15 @@ class AccessibilityManagerActivity : AppActivity() {
         setContent {
             val context = LocalContext.current
             val services = remember(tick) { loadServices(context) }
-            val enabledIds by produceState(initialValue = emptySet<String>(), key1 = tick, context) {
-                value = AccessibilityManager.getEnabledServices(context)
+            val enabledIds = remember(tick) {
+                AccessibilityManager.getEnabledServices(context)
+                    .map { it.flattenToString() }
+                    .toSet()
             }
             val pinnedIds = remember(tick) { AccessibilityKeepAliveStore.getKeepAliveIds() }
             val keepAliveEnabled = remember(tick) { AccessibilityKeepAliveStore.isKeepAliveEnabled() }
             val autoBoot = remember(tick) { AccessibilityKeepAliveStore.isAutoBootEnabled() }
             val shizukuRunning = remember(tick) { Shizuku.pingBinder() }
-            val scope = rememberCoroutineScope()
 
             ShizukuExpressiveTheme {
                 ShizukuLazyScaffold(
@@ -162,26 +160,24 @@ class AccessibilityManagerActivity : AppActivity() {
                                         pinned = pinnedIds.contains(service.id),
                                         canWrite = shizukuRunning,
                                         onToggle = { target ->
-                                            scope.launch {
-                                                // Unpin a service when the user disables it, so the
-                                                // keep-alive daemon doesn't immediately re-enable it
-                                                // (toggle "fight"). Mirrors the reference app's behavior.
-                                                if (!target && AccessibilityKeepAliveStore.isPinned(service.id)) {
-                                                    AccessibilityKeepAliveStore.removePinned(service.id)
-                                                }
-                                                val ok = if (target) {
-                                                    AccessibilityManager.enableService(context, service.id)
-                                                } else {
-                                                    AccessibilityManager.disableService(context, service.id)
-                                                }
-                                                if (!ok) {
-                                                    MaterialAlertDialogBuilder(this@AccessibilityManagerActivity)
-                                                        .setMessage(R.string.accessibility_manager_write_failed)
-                                                        .setPositiveButton(android.R.string.ok, null)
-                                                        .show()
-                                                }
-                                                tick++
+                                            // Unpin a service when the user disables it, so the
+                                            // keep-alive daemon doesn't immediately re-enable it
+                                            // (toggle "fight"). Mirrors the reference app's behavior.
+                                            if (!target && AccessibilityKeepAliveStore.isPinned(service.id)) {
+                                                AccessibilityKeepAliveStore.removePinned(service.id)
                                             }
+                                            val ok = if (target) {
+                                                AccessibilityManager.enableService(context, service.id)
+                                            } else {
+                                                AccessibilityManager.disableService(context, service.id)
+                                            }
+                                            if (!ok) {
+                                                MaterialAlertDialogBuilder(this@AccessibilityManagerActivity)
+                                                    .setMessage(R.string.accessibility_manager_write_failed)
+                                                    .setPositiveButton(android.R.string.ok, null)
+                                                    .show()
+                                            }
+                                            tick++
                                         },
                                         onPin = {
                                             if (AccessibilityKeepAliveStore.isPinned(service.id)) {

--- a/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
@@ -1,5 +1,6 @@
 package moe.shizuku.manager.settings
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.material3.AlertDialog
@@ -11,11 +12,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import moe.shizuku.manager.R
+import moe.shizuku.manager.accessibility.AccessibilityManagerActivity
 import moe.shizuku.manager.app.AppActivity
 import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.manager.service.WatchdogManager
 import moe.shizuku.manager.ui.compose.GroupDivider
 import moe.shizuku.manager.ui.compose.SettingsGroup
+import moe.shizuku.manager.ui.compose.SettingsRow
 import moe.shizuku.manager.ui.compose.ShizukuExpressiveTheme
 import moe.shizuku.manager.ui.compose.ShizukuLazyScaffold
 import moe.shizuku.manager.ui.compose.SwitchSettingsRow
@@ -68,6 +71,21 @@ class LabFeaturesActivity : AppActivity() {
                                         dhizukuEnabled = false
                                         ModuleSettings.setDhizukuEnabled(false)
                                     }
+                                }
+                            )
+                        }
+                    }
+
+                    item {
+                        SettingsGroup(title = stringResource(R.string.accessibility_manager_lab_group)) {
+                            SettingsRow(
+                                icon = R.drawable.ic_system_icon,
+                                title = stringResource(R.string.accessibility_manager_lab_title),
+                                summary = stringResource(R.string.accessibility_manager_lab_summary),
+                                onClick = {
+                                    startActivity(
+                                        Intent(this@LabFeaturesActivity, AccessibilityManagerActivity::class.java)
+                                    )
                                 }
                             )
                         }

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -519,4 +519,25 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="settings_tcp_5555_bind_success">Successfully bound ADB to TCP port 5555</string>
     <string name="settings_tcp_5555_bind_failed">Failed to bind ADB to port 5555: %1$s</string>
     <string name="settings_tcp_5555_bind_failed_generic">Root, Dhizuku, or active Shevery is required.</string>
+
+    <!-- Accessibility Manager -->
+    <string name="accessibility_manager_title">Accessibility Manager</string>
+    <string name="accessibility_manager_lab_group">Accessibility</string>
+    <string name="accessibility_manager_lab_title">Accessibility Manager</string>
+    <string name="accessibility_manager_lab_summary">Manage and keep alive accessibility services</string>
+    <string name="accessibility_manager_keep_alive_group">Keep alive</string>
+    <string name="accessibility_manager_keep_alive_title">Keep pinned services alive</string>
+    <string name="accessibility_manager_keep_alive_summary">Re-enable pinned accessibility services when the system or user disables them</string>
+    <string name="accessibility_manager_auto_boot_title">Start on boot</string>
+    <string name="accessibility_manager_auto_boot_summary">Automatically start the keep-alive daemon after device reboot</string>
+    <string name="accessibility_manager_shizuku_required">Shevery is not running. Start it to enable or disable accessibility services.</string>
+    <string name="accessibility_manager_services_group">Accessibility services (%1$d)</string>
+    <string name="accessibility_manager_services_empty">No installed accessibility services found.</string>
+    <string name="accessibility_manager_service_no_description">No description provided by the service.</string>
+    <string name="accessibility_manager_write_failed">Failed to update accessibility services. Check that Shevery is running and has permission.</string>
+    <string name="accessibility_manager_pin">Pin service to keep alive</string>
+    <string name="accessibility_manager_unpin">Unpin service</string>
+    <string name="accessibility_daemon_channel_name">Accessibility keep-alive</string>
+    <string name="accessibility_daemon_notification_title">Accessibility keep-alive active</string>
+    <string name="accessibility_daemon_notification_text">Pinned accessibility services will be restored if disabled</string>
 </resources>


### PR DESCRIPTION
Closes #71.

## What
Adds an **Accessibility Manager** inside Shevery — **one application, no extra package**. The standalone Accessibility Manager APK is absorbed as a feature; nothing new to install.

## Features
- **Service list** — every installed accessibility service with label, description, and live enable/disable switch
- **Shizuku-native toggling** — writes `settings put secure enabled_accessibility_services` through the Shizuku shell Shevery already owns (no `WRITE_SECURE_SETTINGS` grant needed for the app process)
- **Pin to keep alive** — per-service pin; pinned services are auto-restored if the system or user disables them
- **Keep-alive daemon** — foreground `specialUse` service with three triggers: ContentObserver on `ENABLED_ACCESSIBILITY_SERVICES`, screen-on/user-present receiver, and a 60s heartbeat
- **Boot auto-start** — optional receiver restarts the daemon after reboot
- **Lab Features entry** — under Lab Features → Accessibility Manager

## Files
- `accessibility/AccessibilityManagerActivity.kt` — Compose UI
- `accessibility/AccessibilityManager.kt` — read/write/restore controller (Shizuku shell)
- `accessibility/AccessibilityDaemonService.kt` — keep-alive foreground service
- `accessibility/AccessibilityBootReceiver.kt` — boot auto-start
- `accessibility/AccessibilityKeepAliveStore.kt` — pinned-list persistence
- Manifest, strings, Lab Features row

## Notes
- Pattern-matched against existing screens (SettingsGroup/SwitchSettingsRow/ShizukuLazyScaffold) and the ComputScreen Shizuku shell exec pattern
- Daemon notification uses the existing `specialUse` FGS pattern (same as WatchdogService)

