### PR TITLE
ci: run APK build on PRs targeting dev

### DIFF
--- a/.github/workflows/apk-build.yml
+++ b/.github/workflows/apk-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   workflow_dispatch:
     inputs:
       build_type:


### PR DESCRIPTION
## Why
All PRs are required to target `dev`, but `apk-build.yml` only triggers on PRs to `main`. That means dev-targeting PRs (like #85) never get a CI build automatically — I had to manually trigger `workflow_dispatch` to verify.

## Change
One line: add `dev` to the `pull_request` branch list in `.github/workflows/apk-build.yml`.

```yaml
pull_request:
  branches: [ "main", "dev" ]
```

## Effect
Any PR opened against `dev` now builds automatically on GitHub Actions, so the "all PRs target dev" rule comes with a real build gate.