### PR TITLE
fix: MediaTek/HyperOS user-service startup crash (issue #84)

### DIFF
--- a/api/api/src/main/java/rikka/shizuku/Shizuku.java
+++ b/api/api/src/main/java/rikka/shizuku/Shizuku.java
@@ -459,7 +459,8 @@ public class Shizuku {
      * @see #addBinderDeadListener(OnBinderDeadListener)
      */
     public static boolean pingBinder() {
-        return binder != null && binder.pingBinder();
+        IBinder b = binder;
+        return b != null && b.pingBinder();
     }
 
     private static RuntimeException rethrowAsRuntimeException(RemoteException e) {


### PR DESCRIPTION
## Fixes #84

User services (SD Maid, file managers, etc.) fail to connect on **MediaTek Xiaomi devices running HyperOS**: the reflective Application initialization in `UserService.create()` crashes inside MediaTek's `LoadedApk` private code (`procName` NPE), so the user-service process dies before attaching. Clients see `process is bad` / connection timeouts.

## Root cause

[RikkaApps/Shizuku#1171](https://github.com/RikkaApps/Shizuku/issues/1171) — MediaTek-specific bug in Shizuku v13.6.0+; the [fix](https://github.com/RikkaApps/Shizuku-API/pull/299) was never merged upstream (OG Shizuku development ended). The [thedjchi/Shizuku](https://github.com/thedjchi/Shizuku) fork carries it; this PR ports it.

## Changes

- **`server-shared/.../UserService.java`**: wrap Application init in try-catch; on failure fall back to the old Context-based path (class loader + Context constructor) instead of crashing the process — **byte-identical to thedjchi's fix**
- **`api/.../Shizuku.java`**: fix `pingBinder()` race (read binder into local first) — also from PR #299

## Verification

- `UserService.java` diffed against thedjchi/Shizuku-API: **identical**
- Log evidence in #84: `ContentProviderHelper: Unable to launch app eu.darken.sdmse/12095 for provider eu.darken.sdmse.shizuku: process is bad` — matches the 1171 signature
