### PR TITLE
fix(manager): rename permission-group to avoid INSTALL_FAILED_DUPLICATE_PERMISSION (issue #83)

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:required="false" />
 
     <permission-group
-        android:name="moe.shizuku.manager.permission-group.API"
+        android:name="com.hamondev.shevery.permission-group.API"
         android:description="@string/permission_group_description"
         android:icon="@drawable/ic_system_icon"
         android:label="@string/permission_group_label" />
@@ -45,7 +45,7 @@
         android:description="@string/permission_description"
         android:icon="@drawable/ic_system_icon"
         android:label="@string/permission_label"
-        android:permissionGroup="moe.shizuku.manager.permission-group.API"
+        android:permissionGroup="com.hamondev.shevery.permission-group.API"
         android:protectionLevel="dangerous" />
     <uses-permission
         android:name="moe.shizuku.manager.permission.API_V23"


### PR DESCRIPTION
## What

Ports **only** the permission-group fix from kerneldroid's fork build ([shevery-fork r30](https://github.com/kerneldroid/shevery-fork/releases/tag/r30), commit 2eb8ee8) that resolves issue #83.

## Root cause

The manager manifest declares `moe.shizuku.manager.permission-group.API` — the **same permission-group name** the official Shizuku manager declares. When both packages exist (or stale install state lingers), the package manager rejects the install with `INSTALL_FAILED_DUPLICATE_PERMISSION`. This happens even on devices that never had Shizuku installed (reporter's Samsung A16, ADB mode, v13.9.0.r30).

## The fix (2 lines, cherry-picked)

Rename the permission-group to `com.hamondev.shevery.permission-group.API` in both places:
- the `<permission-group>` declaration
- the `android:permissionGroup` reference on the `API_V23` permission

**Permission names are untouched** (`moe.shizuku.manager.permission.API_V23` etc.), so 3rd-party apps keep working unchanged.

## Scope discipline

Verified via diff that the fork's manifest carried 3 unrelated changes (`<queries>` block from his legacy-stub feature, plus 2 lines main has that his fork lacks) — **none ported**. This PR is exactly the 2-line rename.

Fixes #83