### PR TITLE
change gemini api key example placeholder

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -699,7 +699,7 @@ fun SettingsScreen() {
                     value = tempKey,
                     onValueChange = { tempKey = it },
                     label = { Text(stringResource(R.string.comput_api_key_label)) },
-                    placeholder = { Text("AIzaSy...") },
+                    placeholder = { Text("AQ.Ab8...") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     visualTransformation = if (keyVisible) VisualTransformation.None else PasswordVisualTransformation(),


### PR DESCRIPTION
Changed the Gemini API key example placeholder from AIzaSy to AQ.Ab8.