### PR TITLE
fix(boot): fix inverted pingBinder guard in BootCompleteReceiver

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -32,7 +32,7 @@ class BootCompleteReceiver : BroadcastReceiver() {
             return
         }
 
-        if (UserHandleCompat.myUserId() > 0 || !Shizuku.pingBinder()) return
+        if (UserHandleCompat.myUserId() > 0 || Shizuku.pingBinder()) return
 
         if (ShizukuSettings.getStartOnBootAdb()
             && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {


### PR DESCRIPTION
## Description
Fixes an inverted binder check in \BootCompleteReceiver.kt\.

### Problem
In commit \76a5a5e\, line 35 of \BootCompleteReceiver.kt\ was changed to:
\\\kotlin
if (UserHandleCompat.myUserId() > 0 || !Shizuku.pingBinder()) return
\\\
Because \!Shizuku.pingBinder()\ evaluates to \	rue\ whenever Shizuku/Shevery is not already running on system boot, \BootCompleteReceiver\ would immediately abort and never start the service on device startup.

### Solution
Reverted the guard back to:
\\\kotlin
if (UserHandleCompat.myUserId() > 0 || Shizuku.pingBinder()) return
\\\
Now it correctly returns only if the service is *already* running (or if on a secondary user profile), allowing boot startup (via ADB or Root) to proceed as intended.