### PR TITLE
fix(manager): restore permission-group rename to avoid INSTALL_FAILED_DUPLICATE_PERMISSION

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -56,7 +56,7 @@
         android:required="false" />
 
     <permission-group
-        android:name="moe.shizuku.manager.permission-group.API"
+        android:name="com.hamondev.shevery.permission-group.API"
         android:description="@string/permission_group_description"
         android:icon="@drawable/ic_system_icon"
         android:label="@string/permission_group_label" />
@@ -71,7 +71,7 @@
         android:description="@string/permission_description"
         android:icon="@drawable/ic_system_icon"
         android:label="@string/permission_label"
-        android:permissionGroup="moe.shizuku.manager.permission-group.API"
+        android:permissionGroup="com.hamondev.shevery.permission-group.API"
         android:protectionLevel="dangerous" />
     <uses-permission
         android:name="moe.shizuku.manager.permission.API_V23" />


### PR DESCRIPTION
## Description
Restores the fix originally introduced in PR #88 for Issue #83.

### Problem
During subsequent branch merges into \dev\, \AndroidManifest.xml\ accidentally reverted \permission-group\ back to \moe.shizuku.manager.permission-group.API\.

This causes Android's Package Manager Service (PMS) to throw \INSTALL_FAILED_DUPLICATE_PERMISSION\ / \INSTALL_FAILED_CONFLICTING_PROVIDER\ if users install Shevery alongside official Shizuku, stub companion packages, or previous installations.

### Solution
- Renamed \permission-group\ back to \com.hamondev.shevery.permission-group.API\.
- Updated \permissionGroup\ attribute on \moe.shizuku.manager.permission.API_V23\ to point to \com.hamondev.shevery.permission-group.API\.
- 3rd-party applications only look for \moe.shizuku.manager.permission.API_V23\, so permission handling is unaffected while eliminating package install collisions.

Fixes #83