### PR TITLE
fix(settings): align restore path with init, remove unused import

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -60,7 +60,6 @@ import moe.shizuku.manager.ShizukuSettings.NIGHT_MODE
 import moe.shizuku.manager.app.ThemeHelper
 import moe.shizuku.manager.app.ThemeHelper.KEY_BLACK_NIGHT_THEME
 import moe.shizuku.manager.app.ThemeHelper.KEY_USE_SYSTEM_COLOR
-import moe.shizuku.manager.ktx.isComponentEnabled
 import moe.shizuku.manager.ktx.setComponentEnabled
 import moe.shizuku.manager.compat.StubManager
 import moe.shizuku.manager.module.ModuleSettings
@@ -91,8 +90,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State
+import androidx.lifecycle.Lifecycle
 import android.widget.Toast
 import moe.shizuku.manager.utils.BackupRestoreUtil
 
@@ -260,7 +259,6 @@ fun SettingsScreen() {
             }.onSuccess {
                 Toast.makeText(context, "Restore completed successfully", Toast.LENGTH_SHORT).show()
                 startOnBoot = ShizukuSettings.getStartOnBoot()
-                    || (packageManager.isComponentEnabled(componentName) && !ShizukuSettings.getStartOnBootAdb())
                 adbStartOnBoot = ShizukuSettings.getStartOnBootAdb()
                 errorProtect = ModuleSettings.isErrorProtectEnabled()
                 languageTag = prefs.getString(LANGUAGE, "SYSTEM") ?: "SYSTEM"

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State
 import android.widget.Toast
 import moe.shizuku.manager.utils.BackupRestoreUtil

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -91,7 +91,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.Lifecycle.State
-import androidx.lifecycle.Lifecycle
 import android.widget.Toast
 import moe.shizuku.manager.utils.BackupRestoreUtil
 


### PR DESCRIPTION
Follow-up to PR #123.

- Align restore-path  inference with init: use  only, not the old  formula.
- Remove unused  import.
- Keep  import; still used by .

Addresses review nits from Kimi K3, MiniMax M3, and GLM 5.2.