### PR TITLE
feat(settings): request battery optimization exemption on boot toggle

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import moe.shizuku.manager.ShizukuSettings.NIGHT_MODE
 import moe.shizuku.manager.app.ThemeHelper
 import moe.shizuku.manager.app.ThemeHelper.KEY_BLACK_NIGHT_THEME
 import moe.shizuku.manager.app.ThemeHelper.KEY_USE_SYSTEM_COLOR
+import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.ktx.isComponentEnabled
 import moe.shizuku.manager.ktx.setComponentEnabled
 import moe.shizuku.manager.compat.StubManager
@@ -330,6 +331,9 @@ fun SettingsScreen() {
                             componentName,
                             ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
                         )
+                        if (enabled) {
+                            EnvironmentUtils.requestIgnoreBatteryOptimizations(context)
+                        }
                     }
                 )
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -352,6 +356,7 @@ fun SettingsScreen() {
                                         componentName,
                                         ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
                                     )
+                                    EnvironmentUtils.requestIgnoreBatteryOptimizations(context)
                                     if (!tcpMode) {
                                         Toast.makeText(
                                             context,

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -2,8 +2,13 @@ package moe.shizuku.manager.utils
 
 import android.app.UiModeManager
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
 import android.os.SystemProperties
+import android.provider.Settings
 import android.util.Log
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ShizukuSettings
@@ -78,5 +83,40 @@ object EnvironmentUtils {
         val inTcpMode = ShizukuSettings.isTcpMode()
         // Use TCP directly if: port configured + (TCP mode OR TV device)
         return !(hasTcpPort && (inTcpMode || isTv))
+    }
+
+    @JvmStatic
+    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return true
+        return pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    @JvmStatic
+    fun requestIgnoreBatteryOptimizations(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+        if (isIgnoringBatteryOptimizations(context)) return
+
+        try {
+            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                data = Uri.parse("package:${context.packageName}")
+                if (context !is android.app.Activity) {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            }
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Direct battery optimization request failed, trying settings fallback", e)
+            try {
+                val fallbackIntent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS).apply {
+                    if (context !is android.app.Activity) {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                }
+                context.startActivity(fallbackIntent)
+            } catch (ex: Exception) {
+                Log.e(TAG, "Failed to open battery optimization settings", ex)
+            }
+        }
     }
 }


### PR DESCRIPTION
Cherry-picked from PR #125, targeting dev. Requests battery optimization exemption when the start-on-boot toggle is enabled.