### PR TITLE
fix(settings): clean dev — reapply PRs #123, #124, #125 without accidental main merge

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -58,7 +58,6 @@ import moe.shizuku.manager.ShizukuSettings.NIGHT_MODE
 import moe.shizuku.manager.app.ThemeHelper
 import moe.shizuku.manager.app.ThemeHelper.KEY_BLACK_NIGHT_THEME
 import moe.shizuku.manager.app.ThemeHelper.KEY_USE_SYSTEM_COLOR
-import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.ktx.isComponentEnabled
 import moe.shizuku.manager.ktx.setComponentEnabled
 import moe.shizuku.manager.compat.StubManager
@@ -333,9 +332,6 @@ fun SettingsScreen() {
                             componentName,
                             ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
                         )
-                        if (enabled) {
-                            EnvironmentUtils.requestIgnoreBatteryOptimizations(context)
-                        }
                     }
                 )
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -358,7 +354,6 @@ fun SettingsScreen() {
                                         componentName,
                                         ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
                                     )
-                                    EnvironmentUtils.requestIgnoreBatteryOptimizations(context)
                                     if (!tcpMode) {
                                         Toast.makeText(
                                             context,

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -43,8 +43,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -58,7 +60,6 @@ import moe.shizuku.manager.ShizukuSettings.NIGHT_MODE
 import moe.shizuku.manager.app.ThemeHelper
 import moe.shizuku.manager.app.ThemeHelper.KEY_BLACK_NIGHT_THEME
 import moe.shizuku.manager.app.ThemeHelper.KEY_USE_SYSTEM_COLOR
-import moe.shizuku.manager.ktx.isComponentEnabled
 import moe.shizuku.manager.ktx.setComponentEnabled
 import moe.shizuku.manager.compat.StubManager
 import moe.shizuku.manager.module.ModuleSettings
@@ -85,13 +86,13 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State
 import android.widget.Toast
-import moe.shizuku.manager.accessibility.AccessibilityManagerActivity
-import moe.shizuku.manager.ui.compose.SectionHeader
 import moe.shizuku.manager.utils.BackupRestoreUtil
 
 
@@ -105,10 +106,33 @@ fun SettingsScreen() {
     val prefs = ShizukuSettings.getPreferences()
 
     var startOnBoot by remember {
-        mutableStateOf(
-            ShizukuSettings.getStartOnBoot()
-                || (packageManager.isComponentEnabled(componentName) && !ShizukuSettings.getStartOnBootAdb())
-        )
+        mutableStateOf(ShizukuSettings.getStartOnBoot())
+    }
+    var rooted by remember { mutableStateOf(false) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Root check + one-time stale-pref cleanup on first composition
+    LaunchedEffect(Unit) {
+        rooted = withContext(Dispatchers.IO) { EnvironmentUtils.isRooted() }
+        if (!rooted && ShizukuSettings.getStartOnBoot()) {
+            withContext(Dispatchers.IO) {
+                ShizukuSettings.setStartOnBoot(false)
+                startOnBoot = false
+                packageManager.setComponentEnabled(
+                    componentName,
+                    ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
+                )
+            }
+        }
+    }
+
+    // Re-check root whenever the activity is in the foreground
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            withContext(Dispatchers.IO) {
+                rooted = EnvironmentUtils.isRooted()
+            }
+        }
     }
     var adbStartOnBoot by remember {
         mutableStateOf(ShizukuSettings.getStartOnBootAdb())
@@ -235,7 +259,6 @@ fun SettingsScreen() {
             }.onSuccess {
                 Toast.makeText(context, "Restore completed successfully", Toast.LENGTH_SHORT).show()
                 startOnBoot = ShizukuSettings.getStartOnBoot()
-                    || (packageManager.isComponentEnabled(componentName) && !ShizukuSettings.getStartOnBootAdb())
                 adbStartOnBoot = ShizukuSettings.getStartOnBootAdb()
                 errorProtect = ModuleSettings.isErrorProtectEnabled()
                 languageTag = prefs.getString(LANGUAGE, "SYSTEM") ?: "SYSTEM"
@@ -320,20 +343,25 @@ fun SettingsScreen() {
         item {
             SettingsGroup(title = stringResource(R.string.settings_application)) {
                 SectionHeader(stringResource(R.string.settings_startup))
-                SwitchSettingsRow(
-                    icon = R.drawable.ic_server_restart,
-                    title = stringResource(R.string.settings_start_on_boot),
-                    summary = stringResource(R.string.settings_start_on_boot_summary),
-                    checked = startOnBoot,
-                    onCheckedChange = { enabled ->
-                        ShizukuSettings.setStartOnBoot(enabled)
-                        startOnBoot = ShizukuSettings.getStartOnBoot()
-                        packageManager.setComponentEnabled(
-                            componentName,
-                            ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
-                        )
-                    }
-                )
+                if (rooted) {
+                    SwitchSettingsRow(
+                        icon = R.drawable.ic_server_restart,
+                        title = stringResource(R.string.settings_start_on_boot),
+                        summary = stringResource(R.string.settings_start_on_boot_summary),
+                        checked = startOnBoot,
+                        onCheckedChange = { enabled ->
+                            ShizukuSettings.setStartOnBoot(enabled)
+                            startOnBoot = ShizukuSettings.getStartOnBoot()
+                            packageManager.setComponentEnabled(
+                                componentName,
+                                ShizukuSettings.getStartOnBoot() || ShizukuSettings.getStartOnBootAdb()
+                            )
+                            if (enabled) {
+                                EnvironmentUtils.requestIgnoreBatteryOptimizations(context)
+                            }
+                        }
+                    )
+                }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     SwitchSettingsRow(
                         icon = R.drawable.ic_wadb_24,
@@ -609,14 +637,6 @@ fun SettingsScreen() {
 
         item {
             SettingsGroup(title = stringResource(R.string.settings_sections_title)) {
-                SectionHeader(stringResource(R.string.accessibility_manager_lab_group))
-                SettingsRow(
-                    icon = R.drawable.ic_system_icon,
-                    title = stringResource(R.string.accessibility_manager_lab_title),
-                    summary = stringResource(R.string.accessibility_manager_lab_summary),
-                    onClick = { context.startActivity(Intent(context, AccessibilityManagerActivity::class.java)) }
-                )
-                GroupDivider()
                 SectionHeader(stringResource(R.string.lab_features_title))
                 SettingsRow(
                     icon = R.drawable.ic_settings_outline_24dp,
@@ -912,13 +932,22 @@ fun SettingsScreen() {
     }
 }
 
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 4.dp),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.SemiBold
+    )
+}
+
 private data class LocaleOption(
     val tag: String,
     val title: String,
     val summary: String?
-)
-
-private fun buildLocaleOptions(context: android.content.Context, currentTag: String): List<LocaleOption> {
+)private fun buildLocaleOptions(context: android.content.Context, currentTag: String): List<LocaleOption> {
     val localeTags = ShizukuLocales.LOCALES
     val displayLocaleTags = ShizukuLocales.DISPLAY_LOCALES
     val currentLocale = ShizukuSettings.getLocale()

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -2,8 +2,13 @@ package moe.shizuku.manager.utils
 
 import android.app.UiModeManager
 import android.content.Context
+import android.content.Intent
 import android.content.res.Configuration
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
 import android.os.SystemProperties
+import android.provider.Settings
 import android.util.Log
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ShizukuSettings
@@ -78,5 +83,40 @@ object EnvironmentUtils {
         val inTcpMode = ShizukuSettings.isTcpMode()
         // Use TCP directly if: port configured + (TCP mode OR TV device)
         return !(hasTcpPort && (inTcpMode || isTv))
+    }
+
+    @JvmStatic
+    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return true
+        return pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    @JvmStatic
+    fun requestIgnoreBatteryOptimizations(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+        if (isIgnoringBatteryOptimizations(context)) return
+
+        try {
+            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                data = Uri.parse("package:${context.packageName}")
+                if (context !is android.app.Activity) {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            }
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Direct battery optimization request failed, trying settings fallback", e)
+            try {
+                val fallbackIntent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS).apply {
+                    if (context !is android.app.Activity) {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                }
+                context.startActivity(fallbackIntent)
+            } catch (ex: Exception) {
+                Log.e(TAG, "Failed to open battery optimization settings", ex)
+            }
+        }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -2,13 +2,8 @@ package moe.shizuku.manager.utils
 
 import android.app.UiModeManager
 import android.content.Context
-import android.content.Intent
 import android.content.res.Configuration
-import android.net.Uri
-import android.os.Build
-import android.os.PowerManager
 import android.os.SystemProperties
-import android.provider.Settings
 import android.util.Log
 import com.topjohnwu.superuser.Shell
 import moe.shizuku.manager.ShizukuSettings
@@ -83,40 +78,5 @@ object EnvironmentUtils {
         val inTcpMode = ShizukuSettings.isTcpMode()
         // Use TCP directly if: port configured + (TCP mode OR TV device)
         return !(hasTcpPort && (inTcpMode || isTv))
-    }
-
-    @JvmStatic
-    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true
-        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return true
-        return pm.isIgnoringBatteryOptimizations(context.packageName)
-    }
-
-    @JvmStatic
-    fun requestIgnoreBatteryOptimizations(context: Context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
-        if (isIgnoringBatteryOptimizations(context)) return
-
-        try {
-            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                data = Uri.parse("package:${context.packageName}")
-                if (context !is android.app.Activity) {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-            }
-            context.startActivity(intent)
-        } catch (e: Exception) {
-            Log.w(TAG, "Direct battery optimization request failed, trying settings fallback", e)
-            try {
-                val fallbackIntent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS).apply {
-                    if (context !is android.app.Activity) {
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    }
-                }
-                context.startActivity(fallbackIntent)
-            } catch (ex: Exception) {
-                Log.e(TAG, "Failed to open battery optimization settings", ex)
-            }
-        }
     }
 }

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -399,25 +399,6 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="update_settings_github_pat_delete">Delete token</string>
     <string name="update_settings_github_pat_delete_summary">Remove stored GitHub token</string>
 
-    <!-- Shevery App Updates -->
-    <string name="shevery_update_check_title">Check for Shevery updates</string>
-    <string name="shevery_update_check_summary">Check for newer versions of Shevery manager</string>
-    <string name="shevery_update_checking">Checking for Shevery updates…</string>
-    <string name="shevery_update_up_to_date">Shevery is up to date (%s)</string>
-    <string name="shevery_update_available_title">New Shevery update available!</string>
-    <string name="shevery_update_available_msg">Version %1$s is available (current: %2$s)</string>
-    <string name="shevery_update_download_apk">Download APK</string>
-    <string name="shevery_update_view_release">View on GitHub</string>
-    <string name="shevery_update_channel">Update channel</string>
-    <string name="shevery_update_channel_summary">Choose update release channel</string>
-    <string name="app_update_channel_stable">Stable</string>
-    <string name="app_update_channel_beta">Pre-release &amp; Beta</string>
-    <string name="shevery_update_auto_check">Auto-check on launch</string>
-    <string name="shevery_update_auto_check_summary">Automatically check for Shevery updates on start</string>
-    <string name="shevery_update_group_title">Shevery App Updates</string>
-    <string name="shevery_update_modules_group_title">Module Updates &amp; Catalog</string>
-    <string name="shevery_update_check_failed">Update check failed: %s</string>
-
     <!-- Module Catalog -->
     <string name="modules_catalog">Catalog</string>
     <string name="modules_catalog_title">Module Catalog</string>


### PR DESCRIPTION
Rebuilds dev from main's current tip (1c5cef7) with only our 3 PRs cherry-picked on top:

- PR #123: hide root boot toggle on non-rooted devices, async root check
- PR #124: align restore path with init, cleanup imports
- PR #125: request battery optimization exemption on boot toggle

Removes the accidental main merge artifacts (32 files of unreleased code) that polluted dev in commit 4931e00.