### PR TITLE
fix(boot): prevent crash loop in BootCompleteReceiver.rootStart()

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -301,6 +301,10 @@
             android:name=".connector.ShizukuConnectorProvider"
             android:authorities="${applicationId}.connector;moe.shizuku.privileged.api.connector"
             android:exported="true" />
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse" />
     </application>
 
 </manifest>

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -168,6 +168,12 @@ class BootCompleteReceiver : BroadcastReceiver() {
             com.topjohnwu.superuser.Shell.getCachedShell()?.close()
             return
         }
-        com.topjohnwu.superuser.Shell.cmd(moe.shizuku.manager.starter.Starter.internalCommand).exec()
+        try {
+            moe.shizuku.manager.utils.ShizukuStateMachine.set(moe.shizuku.manager.utils.ShizukuStateMachine.State.STARTING)
+            com.topjohnwu.superuser.Shell.cmd(moe.shizuku.manager.starter.Starter.internalCommand).exec()
+        } catch (e: Exception) {
+            Log.e(AppConstants.TAG, "Failed to start Shizuku with root on boot", e)
+            moe.shizuku.manager.utils.ShizukuStateMachine.update()
+        }
     }
 }


### PR DESCRIPTION
Add try/catch around Shell.cmd().exec() in BootCompleteReceiver.rootStart(). Without this guard, any exception during boot root start would crash the receiver; Android would restart it, creating an infinite loop that WatchdogManager never catches because it monitors the service process, not the receiver.