### PR TITLE
fix(manifest): use specialUse FGS type for AdbPairingService

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -196,8 +196,12 @@
             android:name=".adb.AdbPairingService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="shortService"
-            tools:targetApi="34" />
+            android:foregroundServiceType="specialUse"
+            tools:targetApi="34">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Handles wireless ADB pairing flow, including mDNS discovery, user code entry, and TLS handshake with the remote device." />
+        </service>
 
         <service
             android:name=".dhizuku.DhizukuService"


### PR DESCRIPTION
## Regression
Pairing now fails immediately after submitting the pairing code on API 34+.

## Root cause
AdbPairingService was declared with android:foregroundServiceType="shortService". That type is for short-lived foreground services; the ADB pairing flow is long-running and does mDNS discovery, TLS handshake, and user code entry, so the system kills it during the pairing step.

## Fix
Changed the declaration to android:foregroundServiceType="specialUse" and added the required PROPERTY_SPECIAL_USE_FGS_SUBTYPE, matching WatchdogService and AccessibilityDaemonService.