### PR TITLE
fix(worker): stale 'stopped' notification after successful service start

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -114,14 +114,20 @@ object ShizukuReceiverStarter {
     }
 
     fun updateNotification(context: Context, state: WorkerState) {
-        if (state == WorkerState.STOPPED) return
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        // STOPPED means "no notification" — explicitly cancel any stale one
+        // (previously returned without cancelling, leaving a stale "stopped"
+        // notification visible even after the service started successfully).
+        if (state == WorkerState.STOPPED) {
+            nm.cancel(NOTIFICATION_ID)
+            return
+        }
         val msgId = when (state) {
             WorkerState.AWAITING_WIFI -> R.string.wadb_notification_wifi_required
             WorkerState.AWAITING_RETRY -> R.string.wadb_notification_retry
             else -> null
         }
         val msg = if (msgId != null) context.getString(msgId) else null
-        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.notify(NOTIFICATION_ID, buildNotification(context, msg))
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -216,7 +216,12 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 TimeoutException::class
             )
             if (ignored.none { it.isInstance(e) }) {
-                showErrorNotification(applicationContext, e)
+                // Only surface the error if the service did not actually start —
+                // avoids a stale "stopped/failed" notification coexisting with a
+                // running service (e.g. binder arrived while we were unwinding).
+                if (ShizukuStateMachine.update() != ShizukuStateMachine.State.RUNNING) {
+                    showErrorNotification(applicationContext, e)
+                }
             }
 
             if (ShizukuStateMachine.update() == ShizukuStateMachine.State.RUNNING) {


### PR DESCRIPTION
## Bug
After boot, the work notification would remain visible showing a stale 'stopped' state even though the service had actually started and was running. Tapping it did nothing. Reported by user after reboot autostart testing.

## Root causes (both in WorkManager notification lifecycle)
1. `ShizukuReceiverStarter.updateNotification(STOPPED)` returned early WITHOUT cancelling the existing notification — so if any path had already posted a notification, it stayed up forever even after the service started.
2. `AdbStartWorker` posted the error notification unconditionally before checking whether the service was actually running (the `update() == RUNNING` short-circuit ran after), so a binder arriving while the worker unwound would leave an error notification for a running service.

## Fix
- STOPPED now explicitly cancels the notification (the intended semantics).
- Error notification only posts when the service is confirmed NOT running.