### PR TITLE
fix(watchdog): refresh FGS notification immediately on binder state change

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -21,6 +21,17 @@ class WatchdogService : Service() {
     private var errorProtectJob: Job? = null
     private val errorProtectScope = CoroutineScope(Dispatchers.Default)
 
+    private val binderReceivedListener = object : rikka.shizuku.Shizuku.OnBinderReceivedListener {
+        override fun onBinderReceived() {
+            startAsForeground()
+        }
+    }
+    private val binderDeadListener = object : rikka.shizuku.Shizuku.OnBinderDeadListener {
+        override fun onBinderDead() {
+            startAsForeground()
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         WatchdogManager.init(applicationContext)
@@ -34,10 +45,14 @@ class WatchdogService : Service() {
 
         startAsForeground()
         startErrorProtectLoop()
+        rikka.shizuku.Shizuku.addBinderReceivedListenerSticky(binderReceivedListener)
+        rikka.shizuku.Shizuku.addBinderDeadListener(binderDeadListener)
         return START_STICKY
     }
 
     override fun onDestroy() {
+        rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
+        rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
         stopErrorProtectLoop()
         super.onDestroy()
     }


### PR DESCRIPTION
## Fix
The foreground-service notification was stale for up to a minute after the Shizuku server state changed (start/stop). Android only updates the FGS notification when the service re-calls startForeground(), and on some OEM skins / deep sleep scenarios it lags significantly.

## Solution
Call startForeground() again immediately when Shizuku.OnBinderReceived/OnBinderDead fires, forcing an instant notification refresh. Also remove listeners on service destroy to prevent leaks.