### PR TITLE
fix(worker/notifications): stale notification cleanup + FGS refresh

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -114,14 +114,20 @@ object ShizukuReceiverStarter {
     }
 
     fun updateNotification(context: Context, state: WorkerState) {
-        if (state == WorkerState.STOPPED) return
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        // STOPPED means "no notification" — explicitly cancel any stale one
+        // (previously returned without cancelling, leaving a stale "stopped"
+        // notification visible even after the service started successfully).
+        if (state == WorkerState.STOPPED) {
+            nm.cancel(NOTIFICATION_ID)
+            return
+        }
         val msgId = when (state) {
             WorkerState.AWAITING_WIFI -> R.string.wadb_notification_wifi_required
             WorkerState.AWAITING_RETRY -> R.string.wadb_notification_retry
             else -> null
         }
         val msg = if (msgId != null) context.getString(msgId) else null
-        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.notify(NOTIFICATION_ID, buildNotification(context, msg))
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -21,6 +21,17 @@ class WatchdogService : Service() {
     private var errorProtectJob: Job? = null
     private val errorProtectScope = CoroutineScope(Dispatchers.Default)
 
+    private val binderReceivedListener = object : rikka.shizuku.Shizuku.OnBinderReceivedListener {
+        override fun onBinderReceived() {
+            startAsForeground()
+        }
+    }
+    private val binderDeadListener = object : rikka.shizuku.Shizuku.OnBinderDeadListener {
+        override fun onBinderDead() {
+            startAsForeground()
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         WatchdogManager.init(applicationContext)
@@ -34,10 +45,14 @@ class WatchdogService : Service() {
 
         startAsForeground()
         startErrorProtectLoop()
+        rikka.shizuku.Shizuku.addBinderReceivedListenerSticky(binderReceivedListener)
+        rikka.shizuku.Shizuku.addBinderDeadListener(binderDeadListener)
         return START_STICKY
     }
 
     override fun onDestroy() {
+        rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
+        rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
         stopErrorProtectLoop()
         super.onDestroy()
     }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -216,7 +216,12 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 TimeoutException::class
             )
             if (ignored.none { it.isInstance(e) }) {
-                showErrorNotification(applicationContext, e)
+                // Only surface the error if the service did not actually start —
+                // avoids a stale "stopped/failed" notification coexisting with a
+                // running service (e.g. binder arrived while we were unwinding).
+                if (ShizukuStateMachine.update() != ShizukuStateMachine.State.RUNNING) {
+                    showErrorNotification(applicationContext, e)
+                }
             }
 
             if (ShizukuStateMachine.update() == ShizukuStateMachine.State.RUNNING) {


### PR DESCRIPTION
Contains the notification/worker fixes that were previously merged directly to dev.

- Cancel stale notification when service is confirmed stopped
- Only show error notification when service isn't actually running
- Refresh FGS notification immediately on binder state changes