### PR TITLE
feat(home,watchdog): add persistent TCP prompt dialog, fast-path bypass, and watchdog race protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ signing.properties
 
 **/build/
 *.jks
+.agents/

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuSettings.java
@@ -26,6 +26,8 @@ public class ShizukuSettings {
     public static final String LANGUAGE = "language";
     public static final String KEEP_START_ON_BOOT = "start_on_boot";
     public static final String TCP_MODE = "tcp_mode";
+    public static final String SUPPRESS_TCP_MODE_PROMPT = "suppress_tcp_mode_prompt";
+    public static final String LAST_ADB_PORT = "last_adb_port";
     public static final String AUTO_DISABLE_USB_DEBUGGING = "auto_disable_usb_debugging";
     public static final String START_ON_BOOT_ADB = "start_on_boot_adb";
 
@@ -140,6 +142,22 @@ public class ShizukuSettings {
 
     public static void setStartOnBoot(boolean enabled) {
         getPreferences().edit().putBoolean(KEEP_START_ON_BOOT, enabled).apply();
+    }
+
+    public static boolean isTcpModePromptSuppressed() {
+        return getPreferences().getBoolean(SUPPRESS_TCP_MODE_PROMPT, false);
+    }
+
+    public static void setTcpModePromptSuppressed(boolean suppressed) {
+        getPreferences().edit().putBoolean(SUPPRESS_TCP_MODE_PROMPT, suppressed).apply();
+    }
+
+    public static int getLastAdbPort() {
+        return getPreferences().getInt(LAST_ADB_PORT, -1);
+    }
+
+    public static void setLastAdbPort(int port) {
+        getPreferences().edit().putInt(LAST_ADB_PORT, port).apply();
     }
 
 }

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -22,6 +22,7 @@ object AdbStarter {
         listener: ((ByteArray) -> Unit)? = null,
         log: ((String) -> Unit)? = null,
     ) {
+        moe.shizuku.manager.service.WatchdogManager.expectingDeath = true
         val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
         val tcpMode = ShizukuSettings.isTcpMode()
         val targetPort = if (tcpMode) TCP_MODE_PORT else port
@@ -35,6 +36,7 @@ object AdbStarter {
             log?.invoke("Connecting to ADB on port $targetPort...")
             connectWithRetry(host, targetPort, key) { client ->
                 ShizukuSettings.setLastLaunchMode(ShizukuSettings.LaunchMethod.ADB)
+                ShizukuSettings.setLastAdbPort(targetPort)
                 client.shellCommand(Starter.internalCommand, listener)
             }
         } finally {
@@ -47,6 +49,7 @@ object AdbStarter {
         currentPort: Int,
         targetPort: Int = TCP_MODE_PORT,
     ) {
+        moe.shizuku.manager.service.WatchdogManager.expectingDeath = true
         val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
         switchToTcp(host, currentPort, targetPort, key)
     }

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -50,7 +50,9 @@ import androidx.compose.material.icons.rounded.NearMe
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Terminal
 import androidx.compose.material.icons.rounded.Wifi
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -74,6 +76,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -83,6 +86,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import android.widget.Toast
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -200,6 +204,9 @@ abstract class HomeActivity : AppActivity() {
                 buildLocalNetworkPermissionState()
             }
 
+            var showTcpPromptDialog by rememberSaveable { mutableStateOf(false) }
+            var doNotRemindChecked by rememberSaveable { mutableStateOf(false) }
+
             LaunchedEffect(serviceResource?.status, serviceResource?.data?.uid) {
                 val status = serviceResource?.data ?: return@LaunchedEffect
                 if (serviceResource?.status == Status.SUCCESS && status.isRunning) {
@@ -216,6 +223,16 @@ abstract class HomeActivity : AppActivity() {
                     try {
                         AdbModuleManager.runEnabledServicesIfAllowed(applicationContext)
                     } catch (_: Throwable) {
+                    }
+
+                    val isAdbRunning = status.uid != 0
+                    val needsTcpPrompt = isAdbRunning &&
+                        !ShizukuSettings.isTcpMode() &&
+                        !ShizukuSettings.isTcpModePromptSuppressed()
+
+                    if (!hasPromptedTcpDialogThisSession && needsTcpPrompt) {
+                        hasPromptedTcpDialogThisSession = true
+                        showTcpPromptDialog = true
                     }
                 }
             }
@@ -288,6 +305,106 @@ abstract class HomeActivity : AppActivity() {
                     onItemSelected = { selectedTab = it },
                     modifier = Modifier.align(Alignment.BottomCenter)
                 )
+
+                if (showTcpPromptDialog && !ShizukuSettings.isTcpMode()) {
+                    AlertDialog(
+                        onDismissRequest = {
+                            hasPromptedTcpDialogThisSession = true
+                            if (doNotRemindChecked) {
+                                ShizukuSettings.setTcpModePromptSuppressed(true)
+                            }
+                            showTcpPromptDialog = false
+                        },
+                        title = {
+                            Text(
+                                text = stringResource(R.string.tcp_prompt_dialog_title),
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        },
+                        text = {
+                            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                                Text(
+                                    text = stringResource(R.string.tcp_prompt_dialog_message),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clip(MaterialTheme.shapes.small)
+                                        .clickable { doNotRemindChecked = !doNotRemindChecked }
+                                        .padding(vertical = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Checkbox(
+                                        checked = doNotRemindChecked,
+                                        onCheckedChange = { doNotRemindChecked = it }
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = stringResource(R.string.tcp_prompt_dialog_do_not_remind),
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                }
+                            }
+                        },
+                        confirmButton = {
+                            Button(
+                                onClick = {
+                                    hasPromptedTcpDialogThisSession = true
+                                    if (doNotRemindChecked) {
+                                        ShizukuSettings.setTcpModePromptSuppressed(true)
+                                    }
+                                    showTcpPromptDialog = false
+                                    ShizukuSettings.setTcpMode(true)
+
+                                    lifecycleScope.launch(Dispatchers.IO) {
+                                        val isAlreadyOn5555 = EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT)
+                                        if (isAlreadyOn5555) {
+                                            withContext(Dispatchers.Main) {
+                                                Toast.makeText(this@HomeActivity, R.string.settings_tcp_mode, Toast.LENGTH_SHORT).show()
+                                            }
+                                        } else {
+                                            val port = EnvironmentUtils.getLiveAdbTcpPort().takeIf { it > 0 }
+                                                ?: EnvironmentUtils.getAdbTcpPort().takeIf { it > 0 }
+                                                ?: ShizukuSettings.getLastAdbPort().takeIf { it > 0 }
+                                            if (port != null && port > 0) {
+                                                withContext(Dispatchers.Main) {
+                                                    moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@HomeActivity)
+                                                    startActivity(
+                                                        Intent(this@HomeActivity, StarterActivity::class.java).apply {
+                                                            putExtra(StarterActivity.EXTRA_IS_ROOT, false)
+                                                            putExtra(StarterActivity.EXTRA_HOST, "127.0.0.1")
+                                                            putExtra(StarterActivity.EXTRA_PORT, port)
+                                                        }
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ) {
+                                Text(stringResource(R.string.tcp_prompt_dialog_enable))
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(
+                                onClick = {
+                                    hasPromptedTcpDialogThisSession = true
+                                    if (doNotRemindChecked) {
+                                        ShizukuSettings.setTcpModePromptSuppressed(true)
+                                    }
+                                    showTcpPromptDialog = false
+                                }
+                            ) {
+                                Text(stringResource(R.string.tcp_prompt_dialog_later))
+                            }
+                        },
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        shape = MaterialTheme.shapes.extraLarge
+                    )
+                }
                 }
             }
         }
@@ -660,6 +777,7 @@ abstract class HomeActivity : AppActivity() {
         private const val SDK_ANDROID_17 = 37
         private const val PERMISSION_ACCESS_LOCAL_NETWORK = "android.permission.ACCESS_LOCAL_NETWORK"
         private const val PERMISSION_USE_LOOPBACK_INTERFACE = "android.permission.USE_LOOPBACK_INTERFACE"
+        private var hasPromptedTcpDialogThisSession = false
     }
 }
 

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -194,7 +194,7 @@ object WatchdogManager {
             .apply()
     }
 
-    private fun isUserStopRequested(): Boolean {
+    fun isUserStopRequested(): Boolean {
         return userStopRequested || ShizukuSettings.getPreferences().getBoolean(KEY_USER_STOP_REQUESTED, false)
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -78,7 +78,7 @@ class WatchdogService : Service() {
                     logd("ErrorProtect: Binder check threw exception: ${e.message}")
                 }
 
-                if (!healthy) {
+                if (!healthy && !WatchdogManager.expectingDeath && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
                     logd("ErrorProtect: Service check failed. Stopping and restarting...")
                     withContext(Dispatchers.IO) {
                         moe.shizuku.manager.service.WatchdogManager.stopServer(applicationContext, userInitiated = false)

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -52,7 +52,8 @@ object EnvironmentUtils {
 
     fun getLiveAdbTcpPort(): Int {
         val configuredPort = getAdbTcpPort()
-        val candidates = sequenceOf(configuredPort, 5555)
+        val lastPort = ShizukuSettings.getLastAdbPort()
+        val candidates = sequenceOf(configuredPort, lastPort, 5555)
             .filter { it > 0 }
             .distinct()
 

--- a/manager/src/main/res/values-es/strings.xml
+++ b/manager/src/main/res/values-es/strings.xml
@@ -553,4 +553,11 @@ Listo para comandos.]]></string>
     <string name="settings_restart_dialog_message_wifi_required"><![CDATA[Se necesita conexión Wi-Fi para el primer reinicio, ya que Shevery debe conectarse al puerto de depuración inalámbrico actual antes de cambiar el ADB al 5555.]]></string>
     <string name="adb_pairing_tutorial_content_miui">Es posible que los usuarios de MIUI necesiten cambiar el estilo de notificación a "Android" desde "Notificación" - "Tono de notificación" en la configuración del sistema.</string>
     <string name="comput_no_macros">Aún no hay macros guardadas. Haga clic en \'Grabar macro\' para comenzar a grabar los comandos de la consola.</string>
+
+    <!-- TCP Mode Enable Prompt Dialog -->
+    <string name="tcp_prompt_dialog_title"><![CDATA[¿Activar el modo TCP persistente?]]></string>
+    <string name="tcp_prompt_dialog_message"><![CDATA[Shevery está en ejecución, pero el modo TCP persistente está desactivado.\n\nActivar el modo TCP permite a Shevery mantenerse activo y reconectarse automáticamente en segundo plano, incluso sin Wi-Fi, hasta que el dispositivo se reinicie.]]></string>
+    <string name="tcp_prompt_dialog_enable"><![CDATA[Activar]]></string>
+    <string name="tcp_prompt_dialog_later"><![CDATA[Ahora no]]></string>
+    <string name="tcp_prompt_dialog_do_not_remind"><![CDATA[No volver a recordar]]></string>
 </resources>

--- a/manager/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/src/main/res/values-zh-rCN/strings.xml
@@ -551,4 +551,11 @@
     <string name="shevery_update_modules_group_title"><![CDATA[模块更新与目录]]></string>
     <string name="adb_pairing_tutorial_content_miui">MIUI用户可能需要在系统设置的“通知”-“通知栏”中将通知样​​式切换为“Android”。</string>
     <string name="comput_no_macros">还没有保存的宏。单击“录制宏”开始录制控制台命令。</string>
+
+    <!-- TCP Mode Enable Prompt Dialog -->
+    <string name="tcp_prompt_dialog_title"><![CDATA[开启持久 TCP 模式？]]></string>
+    <string name="tcp_prompt_dialog_message"><![CDATA[Shevery 正在运行，但持久 TCP 模式尚未开启。\n\n开启 TCP 模式可使 Shevery 在离线或后台自动重连（即使未连接 Wi-Fi），直到设备重新启动。]]></string>
+    <string name="tcp_prompt_dialog_enable"><![CDATA[开启]]></string>
+    <string name="tcp_prompt_dialog_later"><![CDATA[暂不开启]]></string>
+    <string name="tcp_prompt_dialog_do_not_remind"><![CDATA[不再提醒]]></string>
 </resources>

--- a/manager/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/src/main/res/values-zh-rTW/strings.xml
@@ -552,4 +552,11 @@
     <string name="settings_compat_stub_none"><![CDATA[沒有可用頻道（請先啟動 Shevery）]]></string>
     <string name="adb_pairing_tutorial_content_miui">MIUI用戶可能需要在系統設定的「通知」-「通知列」中將通知樣切換為「Android」。</string>
     <string name="comput_no_macros">還沒有儲存的巨集。按一下「錄製巨集」開始錄製控制台指令。</string>
+
+    <!-- TCP Mode Enable Prompt Dialog -->
+    <string name="tcp_prompt_dialog_title"><![CDATA[開啟持久 TCP 模式？]]></string>
+    <string name="tcp_prompt_dialog_message"><![CDATA[Shevery 正在運行，但持久 TCP 模式尚未開啟。\n\n開啟 TCP 模式可使 Shevery 在離線或背景自動重連（即使未連線 Wi-Fi），直到裝置重新啟動。]]></string>
+    <string name="tcp_prompt_dialog_enable"><![CDATA[開啟]]></string>
+    <string name="tcp_prompt_dialog_later"><![CDATA[暫不開啟]]></string>
+    <string name="tcp_prompt_dialog_do_not_remind"><![CDATA[不再提醒]]></string>
 </resources>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -618,4 +618,11 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="settings_compat_stub_uninstalled">Legacy stub removed</string>
     <string name="settings_compat_stub_failed">Failed to %1$s the legacy stub via %2$s: %3$s</string>
     <string name="settings_compat_stub_none">No channel available (start Shevery first)</string>
+
+    <!-- TCP Mode Enable Prompt Dialog -->
+    <string name="tcp_prompt_dialog_title">Enable Persistent TCP Mode?</string>
+    <string name="tcp_prompt_dialog_message">Shevery is running, but Persistent TCP Mode is currently disabled.\n\nEnabling TCP Mode allows Shevery to stay running and auto-reconnect in the background—even without Wi-Fi—until your device is restarted.</string>
+    <string name="tcp_prompt_dialog_enable">Enable</string>
+    <string name="tcp_prompt_dialog_later">Not Now</string>
+    <string name="tcp_prompt_dialog_do_not_remind">Don\'t remind me again</string>
 </resources>


### PR DESCRIPTION
### Objective
Provides a seamless opt-in workflow for persistent TCP 5555 mode when Shevery starts via wireless debugging, eliminates redundant restart cycles when port 5555 is already bound, and hardens the watchdog service against false-positive crash recovery loops during manual server restarts.

### Implementation
1. **Interactive TCP Mode Opt-in Dialog (`HomeActivity.kt`)**:
   - Prompts the user to switch to persistent TCP mode upon successful ADB service activation (`status.isRunning && status.uid != 0`) when TCP Mode is not yet enabled in preferences.
   - Includes a *"Don't remind me again"* suppression checkbox persisted via `ShizukuSettings.setTcpModePromptSuppressed()`.
   - **Live 5555 Fast-Path:** If Shevery is already running on static port 5555 (e.g. from previous TCP activation or Dhizuku), confirming the prompt instantly enables `ShizukuSettings.setTcpMode(true)` without triggering a restart or extra system permission dialogs.
   - **Dynamic Port Hand-off:** If running on dynamic Wireless Debugging port (e.g., 38921), confirming delegates to `StarterActivity` to switch ADB to static 5555.
   - Backed by `rememberSaveable` to ensure dialog state survives configuration changes.

2. **Watchdog Race Hardening (`AdbStarter.kt`, `WatchdogService.kt`, `WatchdogManager.kt`)**:
   - Enforces `WatchdogManager.expectingDeath = true` at the beginning of `AdbStarter.start()` to prevent background auto-restart loops from racing with active starter connections.
   - Guards `WatchdogService.kt` `ErrorProtect` loop to only trigger recovery if `!WatchdogManager.expectingDeath && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()`.
   - Exposes `WatchdogManager.isUserStopRequested()` for service-level status checks.

3. **Port Persistence & Discovery (`ShizukuSettings.java`, `EnvironmentUtils.kt`)**:
   - Persists `last_adb_port` in shared preferences.
   - Probes `[configuredPort, lastPort, 5555]` during candidate resolution in `EnvironmentUtils.getLiveAdbTcpPort()` on `Dispatchers.IO`.

4. **Android 17 Local Network Permission Callback (`HomeActivity.kt`)**:
   - Restores the missing `onGranted` callback trigger in `requestLocalNetworkPermission`.

5. **Multi-Language String Resources**:
   - Added translations for TCP prompt dialog across `values/`, `values-es/`, `values-zh-rCN/`, and `values-zh-rTW/`.

### Testing
- [x] Code compiled and verified against compileSdk 37 / targetSdk 37.
- [x] Tested wireless debugging connection and TCP prompt dialog flow.
- [x] Tested live port 5555 fast-path bypass without triggering extra system prompts.
- [x] Tested watchdog death expectation during manual service restart.

### Checklist
- [x] Code follows the existing Kotlin/Compose style and uses `ShizukuExpressiveTheme`.
- [x] Code compiles locally without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.
- [x] Targets `dev` branch as specified in `CONTRIBUTING.md`.

### Screenshots (if applicable)
N/A