### PR TITLE
fix(home): remove conflicting duplicate Toast import

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -86,7 +86,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import android.widget.Toast
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat


### PR DESCRIPTION
### Objective
Removes a duplicate `import android.widget.Toast` in `HomeActivity.kt` that caused Kotlin compilation failure (`Conflicting import: imported name 'Toast' is ambiguous`) during `:manager:compileReleaseKotlin`.

### Implementation
- Cleaned up the redundant `import android.widget.Toast` at line 89 in `HomeActivity.kt`.

### Testing
- [x] Verified via CI GitHub Actions workflow build ([Run #33585452960](https://github.com/CodexofLost/shevery/actions/runs/33585452960)) - 100% build success and APK artifacts generated.