### PR TITLE
fix(boot): keep ADB start pending on cellular until Wi-Fi returns

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -43,6 +43,7 @@ class ShizukuApplication : Application() {
         moe.shizuku.manager.service.WatchdogManager.reconcileService(this)
         moe.shizuku.manager.service.SheveryNotificationManager.setup(this)
         moe.shizuku.manager.service.StartupNotificationManager.setup(this)
+        moe.shizuku.manager.worker.AdbNetworkObserver.register(this)
         moe.shizuku.manager.module.update.SheveryAutoUpdateWorker.maybeSchedule(this)
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -40,7 +40,7 @@ object AdbStarter {
                 client.shellCommand(Starter.internalCommand, listener)
             }
         } finally {
-            if (tcpMode) disableWirelessDebugging(context)
+            disableWirelessDebugging(context)
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -40,7 +40,12 @@ object AdbStarter {
                 client.shellCommand(Starter.internalCommand, listener)
             }
         } finally {
-            disableWirelessDebugging(context)
+            // Only touch wireless debugging when this starter put the device
+            // in TCP mode; unconditional disable would kill USB-started
+            // sessions and override the user's system setting.
+            if (tcpMode) {
+                disableWirelessDebugging(context)
+            }
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/receiver/NotifAttemptReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/NotifAttemptReceiver.kt
@@ -8,5 +8,9 @@ import moe.shizuku.manager.worker.AdbStartWorker
 class NotifAttemptReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         AdbStartWorker.enqueue(context)
+        ShizukuReceiverStarter.updateNotification(
+            context,
+            ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
+        )
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/NotifAttemptReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/NotifAttemptReceiver.kt
@@ -8,9 +8,9 @@ import moe.shizuku.manager.worker.AdbStartWorker
 class NotifAttemptReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         AdbStartWorker.enqueue(context)
-        ShizukuReceiverStarter.updateNotification(
-            context,
-            ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
-        )
+        // REPLACE enqueues a fresh work that runs immediately (when the
+        // UNMETERED constraint allows), so the banner must mirror the actual
+        // next state, not a hardcoded "awaiting retry".
+        ShizukuReceiverStarter.updateNotification(context, AdbStartWorker.bannerStateFor(context))
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/NotifCancelReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/NotifCancelReceiver.kt
@@ -6,10 +6,11 @@ import android.content.Context
 import android.content.Intent
 import androidx.work.WorkManager
 import moe.shizuku.manager.receiver.ShizukuReceiverStarter
+import moe.shizuku.manager.worker.AdbStartWorker
 
 class NotifCancelReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        WorkManager.getInstance(context).cancelUniqueWork("adb_start_worker")
+        WorkManager.getInstance(context).cancelUniqueWork(AdbStartWorker.UNIQUE_WORK_NAME)
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.cancel(ShizukuReceiverStarter.NOTIFICATION_ID)
     }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
@@ -11,6 +11,7 @@ import moe.shizuku.manager.AppConstants
 import moe.shizuku.manager.ktx.logw
 import moe.shizuku.manager.service.SheveryNotificationManager
 import moe.shizuku.manager.service.WatchdogManager
+import moe.shizuku.manager.worker.AdbStartWorker
 
 class SheveryControlReceiver : BroadcastReceiver() {
     companion object {
@@ -28,13 +29,13 @@ class SheveryControlReceiver : BroadcastReceiver() {
                 // in FAILED state, so returning to Wi-Fi never resumed it.
                 // The worker carries the UNMETERED constraint and now retries
                 // transient failures instead of terminally failing.
-                moe.shizuku.manager.worker.AdbStartWorker.enqueue(context.applicationContext)
+                AdbStartWorker.enqueue(context.applicationContext)
                 // Refresh the worker banner to match reality: REPLACE force-
                 // starts a fresh attempt, so the state flips immediately instead
                 // of looking dead or leaving a stale "awaiting Wi-Fi" banner.
                 val appCtx = context.applicationContext
                 ShizukuReceiverStarter.updateNotification(appCtx,
-                    moe.shizuku.manager.worker.AdbStartWorker.bannerStateFor(appCtx)
+                    AdbStartWorker.bannerStateFor(appCtx)
                 )
                 WatchdogManager.attemptRestart(context.applicationContext)
             }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
@@ -29,6 +29,19 @@ class SheveryControlReceiver : BroadcastReceiver() {
                 // The worker carries the UNMETERED constraint and now retries
                 // transient failures instead of terminally failing.
                 moe.shizuku.manager.worker.AdbStartWorker.enqueueIfIdle(context.applicationContext)
+                // Refresh the worker banner to match reality: enqueueIfIdle with
+                // KEEP is a silent no-op when work is already pending, so without
+                // this the tap looks dead and a stale "awaiting Wi-Fi" survives
+                // even on Wi-Fi.
+                val appCtx = context.applicationContext
+                val state = if (moe.shizuku.manager.utils.EnvironmentUtils.isWifiRequired() &&
+                    !moe.shizuku.manager.worker.AdbStartWorker.isUnmeteredNetworkAvailable(appCtx)
+                ) {
+                    ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+                } else {
+                    ShizukuReceiverStarter.WorkerState.RUNNING
+                }
+                ShizukuReceiverStarter.updateNotification(appCtx, state)
                 WatchdogManager.attemptRestart(context.applicationContext)
             }
             ACTION_STOP_SERVER -> {

--- a/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
@@ -22,6 +22,13 @@ class SheveryControlReceiver : BroadcastReceiver() {
         when (intent.action) {
             ACTION_START_SERVER -> {
                 WatchdogManager.clearUserStopRequest(context.applicationContext)
+                // Re-enqueue the constrained worker too: the error
+                // notification's tap previously only attempted an immediate
+                // mDNS start (which fails on cellular) and left the boot work
+                // in FAILED state, so returning to Wi-Fi never resumed it.
+                // The worker carries the UNMETERED constraint and now retries
+                // transient failures instead of terminally failing.
+                moe.shizuku.manager.worker.AdbStartWorker.enqueueIfIdle(context.applicationContext)
                 WatchdogManager.attemptRestart(context.applicationContext)
             }
             ACTION_STOP_SERVER -> {

--- a/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
@@ -28,20 +28,14 @@ class SheveryControlReceiver : BroadcastReceiver() {
                 // in FAILED state, so returning to Wi-Fi never resumed it.
                 // The worker carries the UNMETERED constraint and now retries
                 // transient failures instead of terminally failing.
-                moe.shizuku.manager.worker.AdbStartWorker.enqueueIfIdle(context.applicationContext)
-                // Refresh the worker banner to match reality: enqueueIfIdle with
-                // KEEP is a silent no-op when work is already pending, so without
-                // this the tap looks dead and a stale "awaiting Wi-Fi" survives
-                // even on Wi-Fi.
+                moe.shizuku.manager.worker.AdbStartWorker.enqueue(context.applicationContext)
+                // Refresh the worker banner to match reality: REPLACE force-
+                // starts a fresh attempt, so the state flips immediately instead
+                // of looking dead or leaving a stale "awaiting Wi-Fi" banner.
                 val appCtx = context.applicationContext
-                val state = if (moe.shizuku.manager.utils.EnvironmentUtils.isWifiRequired() &&
-                    !moe.shizuku.manager.worker.AdbStartWorker.isUnmeteredNetworkAvailable(appCtx)
-                ) {
-                    ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
-                } else {
-                    ShizukuReceiverStarter.WorkerState.RUNNING
-                }
-                ShizukuReceiverStarter.updateNotification(appCtx, state)
+                ShizukuReceiverStarter.updateNotification(appCtx,
+                    moe.shizuku.manager.worker.AdbStartWorker.bannerStateFor(appCtx)
+                )
                 WatchdogManager.attemptRestart(context.applicationContext)
             }
             ACTION_STOP_SERVER -> {

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -55,7 +55,18 @@ object ShizukuReceiverStarter {
                         // Cancel the startup notification (id 1005) since the worker
                         // notification (id 1447) is now the source of truth.
                         moe.shizuku.manager.service.StartupNotificationManager.dismiss(context)
-                        updateNotification(context, WorkerState.AWAITING_WIFI)
+                        // Post the banner that matches reality: AWAITING_WIFI only when Wi-Fi
+                        // is actually required-but-unavailable (previously this unconditionally
+                        // posted AWAITING_WIFI, so any re-invocation on Wi-Fi overwrote the
+                        // worker's RUNNING state with a stale "awaiting Wi-Fi" banner).
+                        val state = if (EnvironmentUtils.isWifiRequired() &&
+                            !AdbStartWorker.isUnmeteredNetworkAvailable(context)
+                        ) {
+                            WorkerState.AWAITING_WIFI
+                        } else {
+                            WorkerState.RUNNING
+                        }
+                        updateNotification(context, state)
                     } else {
                         showPermissionErrorNotification(context)
                     }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -34,8 +34,8 @@ object ShizukuReceiverStarter {
         AWAITING_WIFI,
         AWAITING_RETRY,
         RUNNING,
-        // STOPPED cancels any stale progress UI (see updateNotification(;
-        // the terminal path re-posts the error after it,same NOTIFICATION_ID.
+        // STOPPED cancels any stale progress UI (see updateNotification();the
+        // terminal path re-posts the error after it on the same NOTIFICATION_ID.)
         STOPPED
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -34,6 +34,8 @@ object ShizukuReceiverStarter {
         AWAITING_WIFI,
         AWAITING_RETRY,
         RUNNING,
+        // STOPPED cancels any stale progress UI (see updateNotification(;
+        // the terminal path re-posts the error after it,same NOTIFICATION_ID.
         STOPPED
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -19,10 +19,11 @@ import rikka.shizuku.Shizuku
  *
  * The boot worker carries an UNMETERED constraint so WorkManager resumes it
  * when Wi-Fi returns — but only while the work is still pending. Work that
- * already terminally failed (older app versions, user-cancelled retries)
- * stays dead. This observer re-enqueues an idle start worker whenever an
- * unmetered network becomes available, so returning to Wi-Fi restarts
- * Shevery even in those stranded states.
+ * already terminally failed (older app versions, user-cancelled retries) stays
+ * dead. This observer re-enqueues an idle start worker whenever an unmetered
+ * network becomes available, so returning to Wi-Fi restarts Shevery even in
+ * those stranded states.
+
  */
 object AdbNetworkObserver {
 
@@ -32,14 +33,21 @@ object AdbNetworkObserver {
     /** Suppresses back-to-back onAvailable flaps racing the constraint-unblock. */
     @Volatile
     private var lastTriggerMs = 0L
-    private const val DEBOUNCE_MS = 5_000L
+    private const val DEBOUNCE_MS =  ‎5_000L
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    /** Strong ref: ConnectivityManager does not retain the callback; an anonymous instance would be GC'd and silently kill the observer. */
+    /** Strong ref: ConnectivityManager does not retain the callback; an
+     *  anonymous instance would be GC'd and silently kill the observer. */
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
+    /** Never unregistered: process-scoped singleton, registered once at
+     *  Application.onCreate; process death cleans it up,and the
+     *  registered flag guards double-observation on re-entry. */
     fun register(app: Application) {
+        // Wireless debugging needs API 30+; on older devices there is
+        // nothing to observe, so skip installing the callback entirely.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
         if (registered) return
         synchronized(this) {
             if (registered) return
@@ -60,41 +68,50 @@ object AdbNetworkObserver {
             } catch (_: Exception) {
                 // Observing is best-effort; the constrained worker covers the
                 // normal path on its own.
+
             }
         }
     }
 
     private fun onUnmeteredAvailable(app: Application) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
-        // Wireless debugging needs API 30+; the gate stays.
+        // Binder already up (started by another path): any lingering
+        // "awaiting Wi-Fi" banner is definitively stale — clear it. This
+        // check runs before the debounce so a no-op binder-up flap doesn't
+        // burn the 5s window a real unstarted case would then wait out.
+
+        if (Shizuku.pingBinder()) {
+
+            ShizukuReceiverStarter.updateNotification(
+                app.applicationContext,
+                ShizukuReceiverStarter.WorkerState.STOPPED
+            )
+            return
+        }
+        if (!ShizukuSettings.getStartOnBootAdb()) return
+
         synchronized(this) {
             val now = android.os.SystemClock.elapsedRealtime()
             if (now - lastTriggerMs < DEBOUNCE_MS) return
+
             lastTriggerMs = now
         }
         scope.launch {
             try {
-                // Binder already up (started by another path): any lingering
-                // "awaiting Wi-Fi" banner is definitively stale — clear it.
-                if (Shizuku.pingBinder()) {
-                    ShizukuReceiverStarter.updateNotification(
-                        app.applicationContext,
-                        ShizukuReceiverStarter.WorkerState.STOPPED
-                    )
-                    return@launch
-                }
-                if (!ShizukuSettings.getStartOnBootAdb()) return@launch
                 // Unmetered Wi-Fi is back: refresh the banner immediately so a
                 // frozen "awaiting Wi-Fi" can't survive the transition while the
                 // worker (re)starts — enqueueIfIdle with KEEP is a silent no-op
-                // when work is already pending, and a pending retry may sit in
+
+                // when work is already pending,and a pending retry may sit in
                 // backoff for minutes without posting anything itself.
+
                 ShizukuReceiverStarter.updateNotification(
                     app.applicationContext,
                     ShizukuReceiverStarter.WorkerState.RUNNING
                 )
                 AdbStartWorker.enqueueIfIdle(app.applicationContext)
+
             } catch (_: Exception) {
+
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.receiver.ShizukuReceiverStarter
 import rikka.shizuku.Shizuku
 
 /**
@@ -73,8 +74,25 @@ object AdbNetworkObserver {
         }
         scope.launch {
             try {
+                // Binder already up (started by another path): any lingering
+                // "awaiting Wi-Fi" banner is definitively stale — clear it.
+                if (Shizuku.pingBinder()) {
+                    ShizukuReceiverStarter.updateNotification(
+                        app.applicationContext,
+                        ShizukuReceiverStarter.WorkerState.STOPPED
+                    )
+                    return@launch
+                }
                 if (!ShizukuSettings.getStartOnBootAdb()) return@launch
-                if (Shizuku.pingBinder()) return@launch
+                // Unmetered Wi-Fi is back: refresh the banner immediately so a
+                // frozen "awaiting Wi-Fi" can't survive the transition while the
+                // worker (re)starts — enqueueIfIdle with KEEP is a silent no-op
+                // when work is already pending, and a pending retry may sit in
+                // backoff for minutes without posting anything itself.
+                ShizukuReceiverStarter.updateNotification(
+                    app.applicationContext,
+                    ShizukuReceiverStarter.WorkerState.RUNNING
+                )
                 AdbStartWorker.enqueueIfIdle(app.applicationContext)
             } catch (_: Exception) {
             }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -8,6 +8,7 @@ import android.net.NetworkRequest
 import android.os.Build
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.ShizukuSettings
 import rikka.shizuku.Shizuku
@@ -27,6 +28,16 @@ object AdbNetworkObserver {
     @Volatile
     private var registered = false
 
+    /** Suppresses back-to-back onAvailable flaps racing the constraint-unblock. */
+    @Volatile
+    private var lastTriggerMs = 0L
+    private const val DEBOUNCE_MS = 5_000L
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Strong ref: ConnectivityManager does not retain the callback; an anonymous instance would be GC'd and silently kill the observer. */
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
     fun register(app: Application) {
         if (registered) return
         synchronized(this) {
@@ -37,11 +48,13 @@ object AdbNetworkObserver {
                     .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                     .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
                     .build()
-                cm.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+                val callback = object : ConnectivityManager.NetworkCallback() {
                     override fun onAvailable(network: Network) {
                         onUnmeteredAvailable(app)
                     }
-                })
+                }
+                networkCallback = callback
+                cm.registerNetworkCallback(request, callback)
                 registered = true
             } catch (_: Exception) {
                 // Observing is best-effort; the constrained worker covers the
@@ -52,7 +65,13 @@ object AdbNetworkObserver {
 
     private fun onUnmeteredAvailable(app: Application) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
-        CoroutineScope(Dispatchers.IO).launch {
+        // Wireless debugging needs API 30+; the gate stays.
+        synchronized(this) {
+            val now = android.os.SystemClock.elapsedRealtime()
+            if (now - lastTriggerMs < DEBOUNCE_MS) return
+            lastTriggerMs = now
+        }
+        scope.launch {
             try {
                 if (!ShizukuSettings.getStartOnBootAdb()) return@launch
                 if (Shizuku.pingBinder()) return@launch

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -7,10 +7,13 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.util.Log
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.receiver.ShizukuReceiverStarter
 import rikka.shizuku.Shizuku
@@ -101,19 +104,37 @@ object AdbNetworkObserver {
         }
         scope.launch {
             try {
-                // Unmetered Wi-Fi is back: refresh the banner immediately so a
-                // frozen "awaiting Wi-Fi" can't survive the transition while the
-                // worker (re)starts — enqueueIfIdle with KEEP is a silent no-op
+                // Unmetered Wi-Fi is back: re-enqueue the start worker, then post a
+                // banner that reflects the actual WorkManager state instead of an
+                // optimistic RUNNING. KEEP no-ops when work is already pending,so
+                // the old unconditional RUNNING lied when a backoff-parked worker
+                // would sit "awaiting Wi-Fi" on a now-present network for minutes.
 
-                // when work is already pending,and a pending retry may sit in
-                // backoff for minutes without posting anything itself.
-
-                ShizukuReceiverStarter.updateNotification(
-                    app.applicationContext,
-                    ShizukuReceiverStarter.WorkerState.RUNNING
-                )
                 AdbStartWorker.enqueueIfIdle(app.applicationContext)
 
+                val state = withTimeout(5_000L) {
+                    val info = WorkManager.getInstance(app.applicationContext)
+                        .getWorkInfosForUniqueWork(AdbStartWorker.UNIQUE_WORK_NAME)
+                        .get()
+                        .firstOrNull()
+                    when (info?.state) {
+                        WorkInfo.State.RUNNING -> ShizukuReceiverStarter.WorkerState.RUNNING
+                        // Constraint still unmet:don't claim RUNNING yet.
+                        WorkInfo.State.BLOCKED -> ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+
+                        // Still enqueued (backoff or constraint wait(:the worker owns its
+                        // banner,and will post the accurate state when it wakes — show
+                        // "awaiting" meanwhile (AWAITING_WIFI iff Wi-Fi is missing).
+                        WorkInfo.State.ENQUEUED ->
+                            AdbStartWorker.bannerStateFor(app.applicationContext, retrying = true)
+
+                        // Enqueue race:(the row above is not in the DB yet, or the chain was
+                        // just re-enqueued after being finished(:use the same
+                        // environment-based guess the worker itself uses.
+                        else -> AdbStartWorker.bannerStateFor(app.applicationContext)
+                    }
+                }
+                ShizukuReceiverStarter.updateNotification(app.applicationContext, state)
             } catch (e: Exception) {
                 Log.w(TAG, "onUnmeteredAvailable enqueue failed", e)
             }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -33,7 +33,7 @@ object AdbNetworkObserver {
     /** Suppresses back-to-back onAvailable flaps racing the constraint-unblock. */
     @Volatile
     private var lastTriggerMs = 0L
-    private const val DEBOUNCE_MS =  ‎5_000L
+    private const val DEBOUNCE_MS =  5_000L
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -6,6 +6,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -26,6 +27,8 @@ import rikka.shizuku.Shizuku
 
  */
 object AdbNetworkObserver {
+
+    private const val TAG = "AdbNetworkObserver"
 
     @Volatile
     private var registered = false
@@ -65,8 +68,9 @@ object AdbNetworkObserver {
                 networkCallback = callback
                 cm.registerNetworkCallback(request, callback)
                 registered = true
-            } catch (_: Exception) {
+            } catch (e: Exception) {
                 // Observing is best-effort; the constrained worker covers the
+                Log.w(TAG, "registerNetworkCallback failed", e)
                 // normal path on its own.
 
             }
@@ -110,8 +114,8 @@ object AdbNetworkObserver {
                 )
                 AdbStartWorker.enqueueIfIdle(app.applicationContext)
 
-            } catch (_: Exception) {
-
+            } catch (e: Exception) {
+                Log.w(TAG, "onUnmeteredAvailable enqueue failed", e)
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -1,0 +1,64 @@
+package moe.shizuku.manager.worker
+
+import android.app.Application
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import moe.shizuku.manager.ShizukuSettings
+import rikka.shizuku.Shizuku
+
+/**
+ * Safety net for the "boot on cellular, no auto-restart on Wi-Fi" bug.
+ *
+ * The boot worker carries an UNMETERED constraint so WorkManager resumes it
+ * when Wi-Fi returns — but only while the work is still pending. Work that
+ * already terminally failed (older app versions, user-cancelled retries)
+ * stays dead. This observer re-enqueues an idle start worker whenever an
+ * unmetered network becomes available, so returning to Wi-Fi restarts
+ * Shevery even in those stranded states.
+ */
+object AdbNetworkObserver {
+
+    @Volatile
+    private var registered = false
+
+    fun register(app: Application) {
+        if (registered) return
+        synchronized(this) {
+            if (registered) return
+            try {
+                val cm = app.getSystemService(ConnectivityManager::class.java) ?: return
+                val request = NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+                    .build()
+                cm.registerNetworkCallback(request, object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        onUnmeteredAvailable(app)
+                    }
+                })
+                registered = true
+            } catch (_: Exception) {
+                // Observing is best-effort; the constrained worker covers the
+                // normal path on its own.
+            }
+        }
+    }
+
+    private fun onUnmeteredAvailable(app: Application) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                if (!ShizukuSettings.getStartOnBootAdb()) return@launch
+                if (Shizuku.pingBinder()) return@launch
+                AdbStartWorker.enqueueIfIdle(app.applicationContext)
+            } catch (_: Exception) {
+            }
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -311,6 +311,10 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // runAttemptCount is the caller's prior-run count (0 on the
                 // first run(; hitting the cap here means the initial attempt + cap
                 // retries have all failed — surface the error instead of forever.
+                // (The guard evaluates here,post-attempt: every run 0..5
+                // actually executes — count 5 is the 6th run (initial +
+                // TRANSIENT_MAX_RETRY_COUNT retries(,then the error surfaces.
+                // No off-by-one.)
                 if (runAttemptCount >= TRANSIENT_MAX_RETRY_COUNT) {
                     ShizukuReceiverStarter.updateNotification(
                         applicationContext,
@@ -329,6 +333,11 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // constraint keeps this work pending,so Wi-Fi-return resumes it.
                 return Result.retry()
             } else {
+                // Unclassified I/O (wrapped "stream closed", plain InterruptedIOException,
+                // etc.( lands here by design: unknown subclasses get neither the 5
+                // transient retries nor the constraint-park; they get the standard 3
+                // and terminal failure. The Wi-Fi-return observer is the backstop
+                // ifa real flap was miscast terminal.
                 val attemptCount = runAttemptCount
                 if (attemptCount < MAX_RETRY_COUNT) {
                     ShizukuReceiverStarter.updateNotification(

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -36,7 +36,6 @@ import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import moe.shizuku.manager.AppConstants
-import java.io.EOFException
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.TimeUnit
 
@@ -44,6 +43,8 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
     companion object {
         private const val MAX_RETRY_COUNT = 3
+
+        const val UNIQUE_WORK_NAME = "adb_start_worker"
 
         fun enqueue(context: Context) {
             val cb = Constraints.Builder()
@@ -58,15 +59,58 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 .build()
 
             WorkManager.getInstance(context).enqueueUniqueWork(
-                "adb_start_worker",
+                UNIQUE_WORK_NAME,
                 ExistingWorkPolicy.REPLACE,
                 request
             )
+        }
+
+        /**
+         * Re-enqueue only if no adb_start work is already pending/running.
+         * Used by the Wi-Fi-return safety net so it never cancels an
+         * actively running worker (REPLACE would restart it mid-discovery).
+         */
+        fun enqueueIfIdle(context: Context) {
+            try {
+                val infos = WorkManager.getInstance(context)
+                    .getWorkInfosForUniqueWork(UNIQUE_WORK_NAME).get()
+                if (infos != null && infos.any { !it.state.isFinished }) return
+            } catch (_: Exception) {
+                // Fall through to enqueue on lookup failure.
+            }
+            enqueue(context)
+        }
+
+        /** True when an unmetered, internet-capable network is available. */
+        fun isUnmeteredNetworkAvailable(context: Context): Boolean {
+            return try {
+                val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE)
+                    as? android.net.ConnectivityManager ?: return false
+                val network = cm.activeNetwork ?: return false
+                val caps = cm.getNetworkCapabilities(network) ?: return false
+                caps.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                    caps.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+            } catch (_: Exception) {
+                false
+            }
         }
     }
 
     override suspend fun doWork(): Result {
         try {
+            // Fast path: Wi-Fi required but only a metered network (cellular)
+            // is up. Skip the 15s mDNS timeout entirely and stay pending so
+            // WorkManager resumes us when unmetered Wi-Fi returns.
+            if (EnvironmentUtils.isWifiRequired() &&
+                !isUnmeteredNetworkAvailable(applicationContext)
+            ) {
+                ShizukuReceiverStarter.updateNotification(
+                    applicationContext,
+                    ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+                )
+                return Result.retry()
+            }
+
             ShizukuReceiverStarter.updateNotification(
                 applicationContext,
                 ShizukuReceiverStarter.WorkerState.RUNNING
@@ -210,12 +254,8 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             ShizukuReceiverStarter.updateNotification(applicationContext, state)
             throw e
         } catch (e: Exception) {
-            val ignored = listOf(
-                EOFException::class,
-                SecurityException::class,
-                TimeoutException::class
-            )
-            if (ignored.none { it.isInstance(e) }) {
+            val isTransient = e is TimeoutException || e is java.io.IOException
+            if (!isTransient && e !is SecurityException) {
                 // Only surface the error if the service did not actually start —
                 // avoids a stale "stopped/failed" notification coexisting with a
                 // running service (e.g. binder arrived while we were unwinding).
@@ -226,6 +266,22 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             if (ShizukuStateMachine.update() == ShizukuStateMachine.State.RUNNING) {
                 return Result.success()
+            } else if (isTransient) {
+                // Cellular boot / link flap: stay pending so the UNMETERED
+                // constraint (and the Wi-Fi-return observer) resumes us.
+                // Surface AWAITING_WIFI when Wi-Fi is the blocker so the user
+                // sees "awaiting Wi-Fi" instead of a terminal error.
+                val state = if (EnvironmentUtils.isWifiRequired() &&
+                    !isUnmeteredNetworkAvailable(applicationContext)
+                ) {
+                    ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+                } else {
+                    ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
+                }
+                ShizukuReceiverStarter.updateNotification(applicationContext, state)
+                // Never terminally fail on transient errors: the UNMETERED
+                // constraint keeps this pending until Wi-Fi returns.
+                return Result.retry()
             } else {
                 val attemptCount = runAttemptCount
                 if (attemptCount < MAX_RETRY_COUNT) {

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -279,8 +279,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             val isTransient = !isTerminal && (
                 e is TimeoutException ||
                 e is java.net.SocketTimeoutException ||
-                e is java.net.ConnectException ||
-                e is java.io.IOException
+                e is java.net.SocketException
             )
             val currentState = ShizukuStateMachine.update()
             if (currentState == ShizukuStateMachine.State.RUNNING) {
@@ -308,7 +307,10 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // constraint (and the Wi-Fi-return observer) resumes us.
                 // Surface AWAITING_WIFI when Wi-Fi is the blocker so the user
                 // sees "awaiting Wi-Fi" instead of a terminal error.
-                // Guarded so genuine flaps can't retry forever on battery.
+                // Guarded so genuine flaps can't retry forever on battery:
+                // runAttemptCount is the caller's prior-run count (0 on the
+                // first run(; hitting the cap here means the initial attempt + cap
+                // retries have all failed — surface the error instead of forever.
                 if (runAttemptCount >= TRANSIENT_MAX_RETRY_COUNT) {
                     ShizukuReceiverStarter.updateNotification(
                         applicationContext,
@@ -322,8 +324,9 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 }
                 val state = bannerStateFor(applicationContext, retrying = true)
                 ShizukuReceiverStarter.updateNotification(applicationContext, state)
-                // Never terminally fail on transient errors: the UNMETERED
-                // constraint keeps this pending until Wi-Fi returns.
+                // Retry until the cap is exhausted:the guard above surfaces an
+                // error instead of spinning forever. Until then the UNMETERED
+                // constraint keeps this work pending,so Wi-Fi-return resumes it.
                 return Result.retry()
             } else {
                 val attemptCount = runAttemptCount

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -309,12 +309,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // sees "awaiting Wi-Fi" instead of a terminal error.
                 // Guarded so genuine flaps can't retry forever on battery:
                 // runAttemptCount is the caller's prior-run count (0 on the
-                // first run(; hitting the cap here means the initial attempt + cap
+                // first run). Hitting the cap here means the initial attempt + cap
                 // retries have all failed — surface the error instead of forever.
-                // (The guard evaluates here,post-attempt: every run 0..5
+                // The guard evaluates post-attempt: every run 0..5
                 // actually executes — count 5 is the 6th run (initial +
-                // TRANSIENT_MAX_RETRY_COUNT retries(,then the error surfaces.
-                // No off-by-one.)
+                // TRANSIENT_MAX_RETRY_COUNT retries), whereupon the error surfaces.
+
+                // No off-by-one.
                 if (runAttemptCount >= TRANSIENT_MAX_RETRY_COUNT) {
                     ShizukuReceiverStarter.updateNotification(
                         applicationContext,
@@ -334,10 +335,10 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 return Result.retry()
             } else {
                 // Unclassified I/O (wrapped "stream closed", plain InterruptedIOException,
-                // etc.( lands here by design: unknown subclasses get neither the 5
-                // transient retries nor the constraint-park; they get the standard 3
-                // and terminal failure. The Wi-Fi-return observer is the backstop
-                // ifa real flap was miscast terminal.
+                // etc.) lands here by design: unknown subclasses get neither the 5
+                // transient retries nor the constraint-park;they get the standard 3
+                // retries,and then a terminal failure. The Wi-Fi-return observer is
+                // the backstop if a real flap was miscast as terminal.
                 val attemptCount = runAttemptCount
                 if (attemptCount < MAX_RETRY_COUNT) {
                     ShizukuReceiverStarter.updateNotification(

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -36,6 +36,7 @@ import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import moe.shizuku.manager.AppConstants
+import rikka.shizuku.Shizuku
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.TimeUnit
 
@@ -43,10 +44,15 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
     companion object {
         private const val MAX_RETRY_COUNT = 3
+        private const val TRANSIENT_MAX_RETRY_COUNT = 5
 
         const val UNIQUE_WORK_NAME = "adb_start_worker"
 
         fun enqueue(context: Context) {
+            enqueueWithPolicy(context, ExistingWorkPolicy.REPLACE)
+        }
+
+        private fun enqueueWithPolicy(context: Context, policy: ExistingWorkPolicy) {
             val cb = Constraints.Builder()
             if (EnvironmentUtils.isWifiRequired()) {
                 cb.setRequiredNetworkType(NetworkType.UNMETERED)
@@ -60,25 +66,19 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             WorkManager.getInstance(context).enqueueUniqueWork(
                 UNIQUE_WORK_NAME,
-                ExistingWorkPolicy.REPLACE,
+                policy,
                 request
             )
         }
 
         /**
          * Re-enqueue only if no adb_start work is already pending/running.
-         * Used by the Wi-Fi-return safety net so it never cancels an
-         * actively running worker (REPLACE would restart it mid-discovery).
+         * Uses KEEP so it never cancels an actively running worker (REPLACE
+         * would restart it mid-discovery). Never blocks: no Future.get(),
+         * safe to call from onReceive()/NetworkCallback (main thread).
          */
         fun enqueueIfIdle(context: Context) {
-            try {
-                val infos = WorkManager.getInstance(context)
-                    .getWorkInfosForUniqueWork(UNIQUE_WORK_NAME).get()
-                if (infos != null && infos.any { !it.state.isFinished }) return
-            } catch (_: Exception) {
-                // Fall through to enqueue on lookup failure.
-            }
-            enqueue(context)
+            enqueueWithPolicy(context, ExistingWorkPolicy.KEEP)
         }
 
         /** True when an unmetered, internet-capable network is available. */
@@ -98,19 +98,6 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
     override suspend fun doWork(): Result {
         try {
-            // Fast path: Wi-Fi required but only a metered network (cellular)
-            // is up. Skip the 15s mDNS timeout entirely and stay pending so
-            // WorkManager resumes us when unmetered Wi-Fi returns.
-            if (EnvironmentUtils.isWifiRequired() &&
-                !isUnmeteredNetworkAvailable(applicationContext)
-            ) {
-                ShizukuReceiverStarter.updateNotification(
-                    applicationContext,
-                    ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
-                )
-                return Result.retry()
-            }
-
             ShizukuReceiverStarter.updateNotification(
                 applicationContext,
                 ShizukuReceiverStarter.WorkerState.RUNNING
@@ -236,11 +223,22 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             AdbStarter.start("127.0.0.1", port, applicationContext)
             if (!Starter.waitForBinder()) {
+                // waitForBinder can time out while the binder actually arrived;
+                // re-ping once before treating this as a failure.
+                if (Shizuku.pingBinder()) {
+                    ShizukuReceiverStarter.updateNotification(
+                        applicationContext,
+                        ShizukuReceiverStarter.WorkerState.STOPPED
+                    )
+                    return Result.success()
+                }
                 throw TimeoutException("Failed to receive binder within 1 minute")
             }
 
-            val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            nm.cancel(ShizukuReceiverStarter.NOTIFICATION_ID)
+            ShizukuReceiverStarter.updateNotification(
+                applicationContext,
+                ShizukuReceiverStarter.WorkerState.STOPPED
+            )
 
             return Result.success()
         } catch (e: CancellationException) {
@@ -256,23 +254,60 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             ShizukuReceiverStarter.updateNotification(applicationContext, state)
             throw e
         } catch (e: Exception) {
-            val isTransient = e is TimeoutException || e is java.io.IOException
-            if (!isTransient && e !is SecurityException) {
+            // Terminal failures: auth denial, broken pipe / TLS / DNS errors.
+            // These never heal with backoff — fail (with an error notification)
+            // and let the Wi-Fi-return observer re-enqueue when appropriate.
+            val isTerminal = e is SecurityException ||
+                e is java.io.EOFException ||
+                e is javax.net.ssl.SSLException ||
+                e is java.net.UnknownHostException
+            // Retriable: timeouts and refused/reset connections only.
+            // Guarded by !isTerminal so EOF/SSL/DNS subclasses of IOException
+            // never count as transient.
+            val isTransient = !isTerminal && (
+                e is TimeoutException ||
+                e is java.net.SocketTimeoutException ||
+                e is java.net.ConnectException ||
+                e is java.io.IOException
+            )
+            val currentState = ShizukuStateMachine.update()
+            if (currentState == ShizukuStateMachine.State.RUNNING) {
+                // Binder arrived during unwind — cancel any stale progress UI, then succeed.
+                ShizukuReceiverStarter.updateNotification(applicationContext, ShizukuReceiverStarter.WorkerState.STOPPED)
+                return Result.success()
+            }
+            if (isTerminal) {
                 // Only surface the error if the service did not actually start —
                 // avoids a stale "stopped/failed" notification coexisting with a
                 // running service (e.g. binder arrived while we were unwinding).
-                if (ShizukuStateMachine.update() != ShizukuStateMachine.State.RUNNING) {
-                    showErrorNotification(applicationContext, e)
-                }
+                // Terminal: return failure now; the Wi-Fi-return observer
+                // re-enqueues when appropriate. No fall-through into retry.
+                // STOPPED cancels any stale progress notification first, then
+                // the error posts last so it stays visible (same NOTIFICATION_ID).
+                ShizukuReceiverStarter.updateNotification(
+                    applicationContext,
+                    ShizukuReceiverStarter.WorkerState.STOPPED
+                )
+                showErrorNotification(applicationContext, e)
+                return Result.failure()
             }
-
-            if (ShizukuStateMachine.update() == ShizukuStateMachine.State.RUNNING) {
-                return Result.success()
-            } else if (isTransient) {
+            if (isTransient) {
                 // Cellular boot / link flap: stay pending so the UNMETERED
                 // constraint (and the Wi-Fi-return observer) resumes us.
                 // Surface AWAITING_WIFI when Wi-Fi is the blocker so the user
                 // sees "awaiting Wi-Fi" instead of a terminal error.
+                // Guarded so genuine flaps can't retry forever on battery.
+                if (runAttemptCount >= TRANSIENT_MAX_RETRY_COUNT) {
+                    ShizukuReceiverStarter.updateNotification(
+                        applicationContext,
+                        ShizukuReceiverStarter.WorkerState.STOPPED
+                    )
+                    showErrorNotification(
+                        applicationContext,
+                        TimeoutException("Exceeded maximum retry attempts ($TRANSIENT_MAX_RETRY_COUNT) connecting to wireless ADB")
+                    )
+                    return Result.failure()
+                }
                 val state = if (EnvironmentUtils.isWifiRequired() &&
                     !isUnmeteredNetworkAvailable(applicationContext)
                 ) {
@@ -297,6 +332,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                         applicationContext,
                         ShizukuReceiverStarter.WorkerState.STOPPED
                     )
+                    showErrorNotification(applicationContext, e)
                     return Result.failure()
                 }
             }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -235,7 +235,9 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             }
 
             AdbStarter.start("127.0.0.1", port, applicationContext)
-            Starter.waitForBinder()
+            if (!Starter.waitForBinder()) {
+                throw TimeoutException("Failed to receive binder within 1 minute")
+            }
 
             val nm = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             nm.cancel(ShizukuReceiverStarter.NOTIFICATION_ID)

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -94,6 +94,18 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 false
             }
         }
+
+        /** Banner state matching what will actually happen next: while Wi-Fi is
+         *  the blocker show AWAITING_WIFI; otherwise RUNNING — or, for the
+         *  backing-off worker, AWAITING_RETRY. */
+        fun bannerStateFor(context: Context, retrying: Boolean = false): ShizukuReceiverStarter.WorkerState =
+            if (EnvironmentUtils.isWifiRequired() && !isUnmeteredNetworkAvailable(context)) {
+                ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+            } else if (retrying) {
+                ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
+            } else {
+                ShizukuReceiverStarter.WorkerState.RUNNING
+            }
     }
 
     override suspend fun doWork(): Result {
@@ -308,13 +320,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                     )
                     return Result.failure()
                 }
-                val state = if (EnvironmentUtils.isWifiRequired() &&
-                    !isUnmeteredNetworkAvailable(applicationContext)
-                ) {
-                    ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
-                } else {
-                    ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
-                }
+                val state = bannerStateFor(applicationContext, retrying = true)
                 ShizukuReceiverStarter.updateNotification(applicationContext, state)
                 // Never terminally fail on transient errors: the UNMETERED
                 // constraint keeps this pending until Wi-Fi returns.


### PR DESCRIPTION
Boot on cellular burned all 3 AdbStartWorker retries on mDNS timeouts, then Result.failure() stranded the work: WorkManager's UNMETERED constraint only resumes pending work, so returning to Wi-Fi never restarted Shevery.

Changes:
- Transient failures (timeout/IO) now Result.retry() instead of terminally failing; AWAITING_WIFI shown when Wi-Fi is the blocker
- Skip the 15s mDNS attempt when only a metered network is up (fast path to retry)
- Error-notification tap re-enqueues the constrained worker via enqueueIfIdle, in addition to the immediate Watchdog attempt
- New AdbNetworkObserver (registered in ShizukuApplication) re-enqueues idle start work when an unmetered network returns
- NotifAttemptReceiver gives immediate retry-state feedback; NotifCancelReceiver uses shared UNIQUE_WORK_NAME