### PR TITLE
fix: kick backoff-parked start worker when unmetered Wi-Fi returns

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -104,37 +104,35 @@ object AdbNetworkObserver {
         }
         scope.launch {
             try {
-                            // Unmetered Wi-Fi is back: re-enqueue, then post a banner that
-                            // reflects the actual WorkManager state instead of optimistic RUNNING.
-                            // Actively RUNNING work is left alone, since REPLACE would cancel a
-                            // live discovery mid-flight. Everything else is stale now that the
-                            // network is back: REPLACE cancels the pending wait and starts a
-                            // fresh attempt immediately, instead of KEEP no-op'ing, which would
-                            // leave a delayed retry parked until its countdown has expired.
-                            val state = withTimeout(5_000L) {
-                                val info = WorkManager.getInstance(app.applicationContext)
-                                    .getWorkInfosForUniqueWork(AdbStartWorker.UNIQUE_WORK_NAME)
-                                    .get()
-                                    .firstOrNull()
-                                if (info?.state != WorkInfo.State.RUNNING) {
+                // Unmetered Wi-Fi is back: re-enqueue, then post a banner that
+                // reflects the actual WorkManager state instead of optimistic RUNNING.
+                // Actively RUNNING work is left alone, since REPLACE would cancel a
+                // live discovery mid-flight. Everything else is stale now that the
+                // network is back: REPLACE cancels the pending wait and starts a
+                // fresh attempt immediately, instead of KEEP no-op'ing, which would
+                // leave a delayed retry parked until its countdown has expired.
+                val state = withTimeout(5_000L) {
+                    val info = WorkManager.getInstance(app.applicationContext)
+                        .getWorkInfosForUniqueWork(AdbStartWorker.UNIQUE_WORK_NAME)
+                        .get()
+                        .firstOrNull()
+                    if (info?.state != WorkInfo.State.RUNNING) {
 
-                                    AdbStartWorker.enqueue(app.applicationContext)
-                                }
+                        AdbStartWorker.enqueue(app.applicationContext)
+                    }
 
-                                when (info?.state) {
-                                    WorkInfo.State.RUNNING -> ShizukuReceiverStarter.WorkerState.RUNNING
-                                    WorkInfo.State.BLOCKED -> ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+                    when (info?.state) {
+                        WorkInfo.State.RUNNING -> ShizukuReceiverStarter.WorkerState.RUNNING
+                        WorkInfo.State.BLOCKED -> ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
 
-                                    // Post-enqueue race:the fresh row may not be visible yet, or
-                            // the constraint hasn't flipped when we read, so fall back to
-                                    // the worker's own environment-based guess, same as the worker
-                                    // itself uses when it wakes.
-                                    else -> AdbStartWorker.bannerStateFor(app.applicationContext)
-                                }
-                            }
-                        }
-
-                        ShizukuReceiverStarter.updateNotification(app.applicationContext, state)
+                        // Post-enqueue race:the fresh row may not be visible yet, or
+                        // the constraint hasn't flipped when we read, so fall back to
+                        // the worker's own environment-based guess, same as the worker
+                        // itself uses when it wakes.
+                        else -> AdbStartWorker.bannerStateFor(app.applicationContext)
+                }
+                }
+                ShizukuReceiverStarter.updateNotification(app.applicationContext, state)
             } catch (e: Exception) {
                 Log.w(TAG, "onUnmeteredAvailable enqueue failed", e)
             }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -104,37 +104,37 @@ object AdbNetworkObserver {
         }
         scope.launch {
             try {
-                // Unmetered Wi-Fi is back: re-enqueue the start worker, then post a
-                // banner that reflects the actual WorkManager state instead of an
-                // optimistic RUNNING. KEEP no-ops when work is already pending,so
-                // the old unconditional RUNNING lied when a backoff-parked worker
-                // would sit "awaiting Wi-Fi" on a now-present network for minutes.
+                            // Unmetered Wi-Fi is back: re-enqueue, then post a banner that
+                            // reflects the actual WorkManager state instead of optimistic RUNNING.
+                            // Actively RUNNING work is left alone, since REPLACE would cancel a
+                            // live discovery mid-flight. Everything else is stale now that the
+                            // network is back: REPLACE cancels the pending wait and starts a
+                            // fresh attempt immediately, instead of KEEP no-op'ing, which would
+                            // leave a delayed retry parked until its countdown has expired.
+                            val state = withTimeout(5_000L) {
+                                val info = WorkManager.getInstance(app.applicationContext)
+                                    .getWorkInfosForUniqueWork(AdbStartWorker.UNIQUE_WORK_NAME)
+                                    .get()
+                                    .firstOrNull()
+                                if (info?.state != WorkInfo.State.RUNNING) {
 
-                AdbStartWorker.enqueueIfIdle(app.applicationContext)
+                                    AdbStartWorker.enqueue(app.applicationContext)
+                                }
 
-                val state = withTimeout(5_000L) {
-                    val info = WorkManager.getInstance(app.applicationContext)
-                        .getWorkInfosForUniqueWork(AdbStartWorker.UNIQUE_WORK_NAME)
-                        .get()
-                        .firstOrNull()
-                    when (info?.state) {
-                        WorkInfo.State.RUNNING -> ShizukuReceiverStarter.WorkerState.RUNNING
-                        // Constraint still unmet:don't claim RUNNING yet.
-                        WorkInfo.State.BLOCKED -> ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
+                                when (info?.state) {
+                                    WorkInfo.State.RUNNING -> ShizukuReceiverStarter.WorkerState.RUNNING
+                                    WorkInfo.State.BLOCKED -> ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
 
-                        // Still enqueued (backoff or constraint wait(:the worker owns its
-                        // banner,and will post the accurate state when it wakes — show
-                        // "awaiting" meanwhile (AWAITING_WIFI iff Wi-Fi is missing).
-                        WorkInfo.State.ENQUEUED ->
-                            AdbStartWorker.bannerStateFor(app.applicationContext, retrying = true)
+                                    // Post-enqueue race:the fresh row may not be visible yet, or
+                            // the constraint hasn't flipped when we read, so fall back to
+                                    // the worker's own environment-based guess, same as the worker
+                                    // itself uses when it wakes.
+                                    else -> AdbStartWorker.bannerStateFor(app.applicationContext)
+                                }
+                            }
+                        }
 
-                        // Enqueue race:(the row above is not in the DB yet, or the chain was
-                        // just re-enqueued after being finished(:use the same
-                        // environment-based guess the worker itself uses.
-                        else -> AdbStartWorker.bannerStateFor(app.applicationContext)
-                    }
-                }
-                ShizukuReceiverStarter.updateNotification(app.applicationContext, state)
+                        ShizukuReceiverStarter.updateNotification(app.applicationContext, state)
             } catch (e: Exception) {
                 Log.w(TAG, "onUnmeteredAvailable enqueue failed", e)
             }


### PR DESCRIPTION
Fixes the case where returning to Wi-Fi left the AdbStartWorker parked in its retry backoff instead of starting.

## What was wrong
On unmetered-Wi-Fi-return, the observer called enqueueIfIdle, which uses KEEP. KEEP no-ops against existing pending work — so a worker parked mid-backoff ( an 'ENQUEUED' delayed state( stayed parked, showing 'waiting to retry' until either the countdown expired or SOMETHING re-enqueued (opening the app / pressing Start(.

Reported live: home Wi-Fi connect showed 'Shevery is stopped' + 'waiting to retry', and nothing started until the app was opened.,

## Fix
In onUnmeteredAvailable, read the WorkManager state first:
- RUNNING — leave alone, since REPLACE would cancel a live discovery mid-flight
- anything else — enqueue with REPLACE so a stale backoff or constraint wait is canceled and the worker restarts immediately on Wi-Fi return,

Banner mapping kept consistent: BLOCKED still maps to AWAITING_WIFI, everything else falls back to the worker's own environment-based guess.,

Supersedes/no: none. Closes: N/A