### PR TITLE
fix: probe live ADB port directly in start worker before mDNS

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -100,12 +100,18 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             }
 
             val tcpPort = EnvironmentUtils.getAdbTcpPort()
+            val livePort = EnvironmentUtils.getLiveAdbTcpPort()
 
-            val port = if (!EnvironmentUtils.isWifiRequired()) {
+            val port = if (livePort > 0) {
+                livePort
+            } else if (!EnvironmentUtils.isWifiRequired()) {
+
                 tcpPort
             } else if (EnvironmentUtils.isTelevision()) {
+
                 // TV devices with a configured/static TCP port use TCP directly;
                 // avoid mDNS discovery which is unreliable on LEANBACK.
+
                 if (tcpPort > 0) tcpPort else throw SecurityException("TV device requires TCP ADB port to be configured")
             } else {
                 callbackFlow {


### PR DESCRIPTION
## Problem

On Wi-Fi return, the observer enqueues `AdbStartWorker`, but the worker's first attempt to connect failed and got stuck rounds 'Waiting to retry' — while launching the app (which probes direct ports( started the service instantly.

## Root cause

The worker resolved the port via **mDNS/Nsd discovery** (or required `service.adb.tcp.port`(, which is unreliable from a background-triggered process. The UI/app-open path instead probes **direct known ports** — `configured -> last-known -> 5555` — with a 250ms socket check each, so it finds the already-listening adbd in under elsea second.



## Fix

`AdbStartWorker` now tries `EnvironmentUtils.getLiveAdbTcpPort()` first (same helper asthe UI path(; mDNS discovery remains only as fallback for wifi-required phones when no direct port is live.



## Test

- Enable wireless debugging ADB, start service, disconnect Wi-Fi, reconnect — service should auto-restart within ~1s of network reconnection (no 'Waiting to retry' cycle(%.