### PR TITLE
fix: worker survives Wi-Fi-off boot in TCP mode (match reference contract)

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/ShizukuReceiverStarter.kt
@@ -61,9 +61,11 @@ object ShizukuReceiverStarter {
                         // is actually required-but-unavailable (previously this unconditionally
                         // posted AWAITING_WIFI, so any re-invocation on Wi-Fi overwrote the
                         // worker's RUNNING state with a stale "awaiting Wi-Fi" banner).
-                        val state = if (EnvironmentUtils.isWifiRequired() &&
-                            !AdbStartWorker.isUnmeteredNetworkAvailable(context)
-                        ) {
+                        // Parked while no unmetered network exists — same condition as
+                        // the worker's constraint (see AdbStartWorker.enqueueWithPolicy);
+                        // TCP mode does NOT mean the boot can run without Wi-Fi: wireless
+                        // ADB still needs the live local network to discover/connect.
+                        val state = if (!AdbStartWorker.isUnmeteredNetworkAvailable(context)) {
                             WorkerState.AWAITING_WIFI
                         } else {
                             WorkerState.RUNNING

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -171,10 +171,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
                     var awaitingAuth = false
                     var timeoutJob: Job? = null
+                    var authWaitJob: Job? = null
                     var unlockReceiver: BroadcastReceiver? = null
 
                     fun startDiscoveryWithTimeout() {
                         adbMdns.start()
+                        authWaitJob?.cancel()
+                        authWaitJob = null
                         timeoutJob?.cancel()
                         timeoutJob = this.launch {
                             delay(15_000)
@@ -184,44 +187,65 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
                     fun handleAuth() {
                         val km = applicationContext.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+                        timeoutJob?.cancel()
+                        timeoutJob = null
+                        adbMdns.stop()
+                        authWaitJob?.cancel()
+                        authWaitJob = null
                         if (km.isKeyguardLocked) {
-                            val filter = IntentFilter(Intent.ACTION_USER_PRESENT)
-                            unlockReceiver = object : BroadcastReceiver() {
-                                override fun onReceive(context: Context, intent: Intent) {
-                                    if (intent.action == Intent.ACTION_USER_PRESENT) {
-                                        context.unregisterReceiver(this)
-                                        unlockReceiver = null
-                                        Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                            if (unlockReceiver == null) {
+                                val filter = IntentFilter(Intent.ACTION_USER_PRESENT)
+                                unlockReceiver = object : BroadcastReceiver() {
+                                    override fun onReceive(context: Context, intent: Intent) {
+                                        if (intent.action == Intent.ACTION_USER_PRESENT) {
+                                            context.unregisterReceiver(this)
+                                            unlockReceiver = null
+                                            Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                                        }
                                     }
                                 }
+                                val receiverFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                    ContextCompat.RECEIVER_EXPORTED
+                                } else {
+                                    ContextCompat.RECEIVER_NOT_EXPORTED
+                                }
+                                ContextCompat.registerReceiver(
+                                    applicationContext,
+                                    unlockReceiver,
+                                    filter,
+                                    receiverFlags
+                                )
                             }
-                            val receiverFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                ContextCompat.RECEIVER_EXPORTED
-                            } else {
-                                ContextCompat.RECEIVER_NOT_EXPORTED
+                            // Bound the unlock wait: an uncapped wait wedges the worker
+                            // when the flag flaps during Wi-Fi bring-up. This timeout is
+                            // transient, so a later retry (or the unlock) resumes us.
+                            authWaitJob = this.launch {
+                                delay(60_000)
+                                close(TimeoutException("Timed out waiting for unlock to authorize wireless debugging"))
                             }
-                            ContextCompat.registerReceiver(
-                                applicationContext,
-                                unlockReceiver,
-                                filter,
-                                receiverFlags
-                            )
                         } else {
+                            // System cleared adb_wifi_enabled mid-run (typical during
+                            // Wi-Fi bring-up). Re-assert once and resume discovery under
+                            // timeout instead of wedging; a repeat clear surfaces as a
+                            // transient timeout below, never terminal death.
                             awaitingAuth = true
+                            runCatching { Settings.Global.putInt(cr, "adb_wifi_enabled", 1) }
+                            startDiscoveryWithTimeout()
                         }
-                        timeoutJob?.cancel()
-                        adbMdns.stop()
                     }
 
                     val observer = object : ContentObserver(null) {
                         override fun onChange(selfChange: Boolean) {
                             when (Settings.Global.getInt(cr, "adb_wifi_enabled", 0)) {
                                 0 -> if (awaitingAuth) {
-                                    close(SecurityException("Network is not authorized for wireless debugging"))
+                                    close(TimeoutException("Wireless debugging was disabled again mid-run"))
                                 } else {
                                     handleAuth()
                                 }
-                                1 -> startDiscoveryWithTimeout()
+                                1 -> {
+                                    awaitingAuth = false
+                                    startDiscoveryWithTimeout()
+                                }
                             }
                         }
                     }
@@ -235,6 +259,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
                     awaitClose {
                         adbMdns.stop()
+                        authWaitJob?.cancel()
                         timeoutJob?.cancel()
                         cr.unregisterContentObserver(observer)
                         unlockReceiver?.let {

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -43,9 +43,6 @@ import java.util.concurrent.TimeUnit
 class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
 
     companion object {
-        private const val MAX_RETRY_COUNT = 3
-        private const val TRANSIENT_MAX_RETRY_COUNT = 5
-
         const val UNIQUE_WORK_NAME = "adb_start_worker"
 
         fun enqueue(context: Context) {
@@ -55,10 +52,11 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
         private fun enqueueWithPolicy(context: Context, policy: ExistingWorkPolicy) {
             val cb = Constraints.Builder()
 
-            // Wireless ADB needs a live unmetered LAN: park while none exists,
-            // regardless of TCP mode, so WorkManager itself resumes this on Wi-Fi return.
-
-            if (EnvironmentUtils.isWifiRequired() || !isUnmeteredNetworkAvailable(context)) {
+            // Matches the reference implementation (thedjchi/Shizuku): only
+            // constrain on UNMETERED when wireless discovery actually needs
+            // Wi-Fi. In TCP mode adbd listens on loopback regardless of Wi-Fi
+            // state, so the worker runs immediately and connects directly.
+            if (EnvironmentUtils.isWifiRequired()) {
                 cb.setRequiredNetworkType(NetworkType.UNMETERED)
             }
             val constraints = cb.build()
@@ -304,95 +302,31 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             ShizukuReceiverStarter.updateNotification(applicationContext, state)
             throw e
         } catch (e: Exception) {
-            // Terminal failures: auth denial, broken pipe / TLS / DNS errors.
-            // These never heal with backoff — fail (with an error notification)
-            // and let the Wi-Fi-return observer re-enqueue when appropriate.
-            val isTerminal = e is SecurityException ||
-                e is java.io.EOFException ||
-                e is javax.net.ssl.SSLException ||
-                e is java.net.UnknownHostException
-            // Retriable: timeouts and refused/reset connections only.
-            // Guarded by !isTerminal so EOF/SSL/DNS subclasses of IOException
-            // never count as transient.
-            val isTransient = !isTerminal && (
-                e is TimeoutException ||
-                e is java.net.SocketTimeoutException ||
-                e is java.net.SocketException
+            // Matches the reference implementation (thedjchi/Shizuku): the
+            // auto-start worker never terminally fails. Anything below a
+            // running binder — adbd restarts, TLS/key flaps, mDNS misses,
+            // Wi-Fi bring-up races — heals with backoff, so retry until the
+            // binder is up. Failing here strands the device until the next
+            // boot or a manual start.
+            val ignored = listOf(
+                java.io.EOFException::class,
+                SecurityException::class,
+                TimeoutException::class,
+                javax.net.ssl.SSLException::class,
+                java.net.UnknownHostException::class
             )
-            val currentState = ShizukuStateMachine.update()
-            if (currentState == ShizukuStateMachine.State.RUNNING) {
+            if (ignored.none { it.isInstance(e) }) showErrorNotification(applicationContext, e)
+
+            if (ShizukuStateMachine.update() == ShizukuStateMachine.State.RUNNING) {
                 // Binder arrived during unwind — cancel any stale progress UI, then succeed.
                 ShizukuReceiverStarter.updateNotification(applicationContext, ShizukuReceiverStarter.WorkerState.STOPPED)
                 return Result.success()
             }
-            if (isTerminal) {
-                // Only surface the error if the service did not actually start —
-                // avoids a stale "stopped/failed" notification coexisting with a
-                // running service (e.g. binder arrived while we were unwinding).
-                // Terminal: return failure now; the Wi-Fi-return observer
-                // re-enqueues when appropriate. No fall-through into retry.
-                // STOPPED cancels any stale progress notification first, then
-                // the error posts last so it stays visible (same NOTIFICATION_ID).
-                ShizukuReceiverStarter.updateNotification(
-                    applicationContext,
-                    ShizukuReceiverStarter.WorkerState.STOPPED
-                )
-                showErrorNotification(applicationContext, e)
-                return Result.failure()
-            }
-            if (isTransient) {
-                // Cellular boot / link flap: stay pending so the UNMETERED
-                // constraint (and the Wi-Fi-return observer) resumes us.
-                // Surface AWAITING_WIFI when Wi-Fi is the blocker so the user
-                // sees "awaiting Wi-Fi" instead of a terminal error.
-                // Guarded so genuine flaps can't retry forever on battery:
-                // runAttemptCount is the caller's prior-run count (0 on the
-                // first run). Hitting the cap here means the initial attempt + cap
-                // retries have all failed — surface the error instead of forever.
-                // The guard evaluates post-attempt: every run 0..5
-                // actually executes — count 5 is the 6th run (initial +
-                // TRANSIENT_MAX_RETRY_COUNT retries), whereupon the error surfaces.
-
-                // No off-by-one.
-                if (runAttemptCount >= TRANSIENT_MAX_RETRY_COUNT) {
-                    ShizukuReceiverStarter.updateNotification(
-                        applicationContext,
-                        ShizukuReceiverStarter.WorkerState.STOPPED
-                    )
-                    showErrorNotification(
-                        applicationContext,
-                        TimeoutException("Exceeded maximum retry attempts ($TRANSIENT_MAX_RETRY_COUNT) connecting to wireless ADB")
-                    )
-                    return Result.failure()
-                }
-                val state = bannerStateFor(applicationContext, retrying = true)
-                ShizukuReceiverStarter.updateNotification(applicationContext, state)
-                // Retry until the cap is exhausted:the guard above surfaces an
-                // error instead of spinning forever. Until then the UNMETERED
-                // constraint keeps this work pending,so Wi-Fi-return resumes it.
-                return Result.retry()
-            } else {
-                // Unclassified I/O (wrapped "stream closed", plain InterruptedIOException,
-                // etc.) lands here by design: unknown subclasses get neither the 5
-                // transient retries nor the constraint-park;they get the standard 3
-                // retries,and then a terminal failure. The Wi-Fi-return observer is
-                // the backstop if a real flap was miscast as terminal.
-                val attemptCount = runAttemptCount
-                if (attemptCount < MAX_RETRY_COUNT) {
-                    ShizukuReceiverStarter.updateNotification(
-                        applicationContext,
-                        ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
-                    )
-                    return Result.retry()
-                } else {
-                    ShizukuReceiverStarter.updateNotification(
-                        applicationContext,
-                        ShizukuReceiverStarter.WorkerState.STOPPED
-                    )
-                    showErrorNotification(applicationContext, e)
-                    return Result.failure()
-                }
-            }
+            ShizukuReceiverStarter.updateNotification(
+                applicationContext,
+                ShizukuReceiverStarter.WorkerState.AWAITING_RETRY
+            )
+            return Result.retry()
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -144,12 +144,20 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             val tcpPort = EnvironmentUtils.getAdbTcpPort()
 
-            val port = if (!EnvironmentUtils.isWifiRequired()) {
-                tcpPort
-            } else if (EnvironmentUtils.isTelevision()) {
+            val port = if (EnvironmentUtils.isTelevision()) {
                 // TV devices with a configured/static TCP port use TCP directly;
                 // avoid mDNS discovery which is unreliable on LEANBACK.
                 if (tcpPort > 0) tcpPort else throw SecurityException("TV device requires TCP ADB port to be configured")
+            } else if (!EnvironmentUtils.isWifiRequired() && EnvironmentUtils.isAdbPortLive(tcpPort)) {
+
+                // A configured/static TCP port that is actually live can be used directly.
+
+                // NOTE: TCP mode alone does NOT imply the port is live: adbd's wireless
+                // debugging port is random per boot,and 5555 (TCP_MODE_PORT( exists only
+                // AFTER the first successful start rebinds adbd to it. When a configured port
+                // is stale (e.g., fresh reboot before the service started(, fall through to mDNS
+                // so the worker still discovers the live random wireless port.
+                tcpPort
             } else {
                 callbackFlow {
                     val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -54,7 +54,11 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
         private fun enqueueWithPolicy(context: Context, policy: ExistingWorkPolicy) {
             val cb = Constraints.Builder()
-            if (EnvironmentUtils.isWifiRequired()) {
+
+            // Wireless ADB needs a live unmetered LAN: park while none exists,
+            // regardless of TCP mode, so WorkManager itself resumes this on Wi-Fi return.
+
+            if (EnvironmentUtils.isWifiRequired() || !isUnmeteredNetworkAvailable(context)) {
                 cb.setRequiredNetworkType(NetworkType.UNMETERED)
             }
             val constraints = cb.build()
@@ -99,7 +103,8 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
          *  the blocker show AWAITING_WIFI; otherwise RUNNING — or, for the
          *  backing-off worker, AWAITING_RETRY. */
         fun bannerStateFor(context: Context, retrying: Boolean = false): ShizukuReceiverStarter.WorkerState =
-            if (EnvironmentUtils.isWifiRequired() && !isUnmeteredNetworkAvailable(context)) {
+            // Matches the enqueue constraint: parked while no unmetered LAN exists.
+            if (!isUnmeteredNetworkAvailable(context)) {
                 ShizukuReceiverStarter.WorkerState.AWAITING_WIFI
             } else if (retrying) {
                 ShizukuReceiverStarter.WorkerState.AWAITING_RETRY


### PR DESCRIPTION
Against the reference (thedjchi/Shizuku):

1. No UNMETERED park in TCP mode — the worker runs immediately at boot instead of sitting BLOCKED waiting for Wi-Fi. If the stored port still probes live it is reused, otherwise it falls through to mDNS discovery (required on Android 16 late / 17+ where the wireless port is randomized per boot). Wi-Fi-off just means discovery times out transiently and retries with backoff once Wi-Fi returns — nothing strands.
2. The auto-start worker never terminally fails — every sub-RUNNING outcome (EOF/TLS/DNS/auth/timeout) returns Result.retry() with exponential backoff (30s base) until the binder is up. No attempt cap, so effectively infinite until success or explicit cancel. The old 6-attempt cap and terminal failures stranded the device until the next boot or a manual start.
3. Bounded handleAuth waits — the wireless-debugging auth dance (adb_wifi_enabled flag + keyguard) waits at most 60s for unlock, and when unlocked re-asserts the flag once then resumes discovery under a 15s timeout, instead of the old unbounded USER_PRESENT wait that wedged the worker when the flag flapped during Wi-Fi bring-up.

Kept from the fork: TCP liveness gate, port resolve queue, keyguard handling, Wi-Fi-return observer as backstop, AWAITING_WIFI/RETRY banners.