### PR TITLE
fix(starter): resolve 'Waiting for service...' hang with ContentProvider backoff and starter watchdog

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/ShizukuManagerProvider.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuManagerProvider.kt
@@ -27,7 +27,30 @@ class ShizukuManagerProvider : ShizukuProvider() {
     override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
         if (extras == null) return null
 
-        return if (method == METHOD_SEND_USER_SERVICE) {
+        return when (method) {
+            METHOD_SEND_BINDER -> {
+                try {
+                    extras.classLoader = BinderContainer::class.java.classLoader
+                    val container = extras.getParcelable<BinderContainer>(EXTRA_BINDER)
+                        ?: extras.getParcelable<BinderContainer>(EXTRA_BINDER_SHEVERY)
+                    val newBinder = container?.binder
+                    if (newBinder != null) {
+                        // Accept if no living binder OR if this is a new replacement binder from a restarted server
+                        if (!Shizuku.pingBinder() || Shizuku.getBinder() != newBinder) {
+                            LOGGER.i("Received new/replacement Shizuku server binder in manager provider")
+                            val pkg = context?.packageName ?: "com.hamondev.shevery"
+                            Shizuku.onBinderReceived(newBinder, pkg)
+                        } else {
+                            LOGGER.d("sendBinder ignored: identical living binder already registered")
+                        }
+                    }
+                    Bundle()
+                } catch (e: Throwable) {
+                    LOGGER.e(e, "sendBinder")
+                    super.call(method, arg, extras)
+                }
+            }
+            METHOD_SEND_USER_SERVICE -> {
             try {
                 extras.classLoader = BinderContainer::class.java.classLoader
 
@@ -96,8 +119,9 @@ class ShizukuManagerProvider : ShizukuProvider() {
                 LOGGER.e(e, "sendUserService")
                 null
             }
-        } else {
-            super.call(method, arg, extras)
         }
+        else -> super.call(method, arg, extras)
     }
 }
+}
+

--- a/manager/src/main/java/moe/shizuku/manager/ShizukuManagerProvider.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuManagerProvider.kt
@@ -38,7 +38,7 @@ class ShizukuManagerProvider : ShizukuProvider() {
                         // Accept if no living binder OR if this is a new replacement binder from a restarted server
                         if (!Shizuku.pingBinder() || Shizuku.getBinder() != newBinder) {
                             LOGGER.i("Received new/replacement Shizuku server binder in manager provider")
-                            val pkg = context?.packageName ?: "com.hamondev.shevery"
+                            val pkg = context?.packageName ?: BuildConfig.APPLICATION_ID
                             Shizuku.onBinderReceived(newBinder, pkg)
                         } else {
                             LOGGER.d("sendBinder ignored: identical living binder already registered")

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -9,12 +9,15 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.AppConstants.EXTRA
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
@@ -40,7 +43,6 @@ private class DhizukuException(message: String, cause: Throwable? = null) : Exce
 class StarterActivity : AppActivity() {
 
     private var waitingForService = false
-    private var binderReceivedListener: Shizuku.OnBinderReceivedListener? = null
 
     private val viewModel by viewModels {
         ViewModel(
@@ -50,14 +52,6 @@ class StarterActivity : AppActivity() {
             intent.getStringExtra(EXTRA_HOST),
             intent.getIntExtra(EXTRA_PORT, 0)
         )
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        binderReceivedListener?.let {
-            Shizuku.removeBinderReceivedListener(it)
-            binderReceivedListener = null
-        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -79,24 +73,46 @@ class StarterActivity : AppActivity() {
                 }, 3000)
             } else if (!waitingForService && finished) {
                 waitingForService = true
-                viewModel.appendOutput("")
-                viewModel.appendOutput("Waiting for service...")
+                if (Shizuku.pingBinder() || ShizukuStateMachine.isRunning()) {
+                    moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@StarterActivity)
+                    viewModel.appendOutput("")
+                    viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
+                    window?.decorView?.postDelayed({
+                        if (!isFinishing) finish()
+                    }, 3000)
+                } else {
+                    viewModel.appendOutput("")
+                    viewModel.appendOutput("Waiting for service...")
 
-                val listener = object : Shizuku.OnBinderReceivedListener {
-                    override fun onBinderReceived() {
-                        Shizuku.removeBinderReceivedListener(this)
-                        binderReceivedListener = null
-                        runOnUiThread {
+                    lifecycleScope.launch {
+                        var running = false
+                        val startTime = System.currentTimeMillis()
+                        while (!running && (System.currentTimeMillis() - startTime) < 12_000L) {
+                            if (Shizuku.pingBinder() || ShizukuStateMachine.isRunning()) {
+                                ShizukuStateMachine.set(ShizukuStateMachine.State.RUNNING)
+                                running = true
+                                break
+                            }
+                            withTimeoutOrNull(500L) {
+                                ShizukuStateMachine.asFlow().first { it == ShizukuStateMachine.State.RUNNING }
+                                running = true
+                            }
+                        }
+
+                        if (running) {
                             moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@StarterActivity)
                             viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
                             window?.decorView?.postDelayed({
                                 if (!isFinishing) finish()
                             }, 3000)
+                        } else {
+                            viewModel.appendOutput("")
+                            viewModel.appendOutput("✗ Timed out waiting for Shevery service to initialize.")
+                            viewModel.appendOutput("  The starter process completed, but the server binder was not received.")
+                            viewModel.appendOutput("  Please try starting again, or check background battery restrictions.")
                         }
                     }
                 }
-                binderReceivedListener = listener
-                Shizuku.addBinderReceivedListenerSticky(listener)
             } else if (it.status == Status.ERROR) {
                 var message = 0
                 when (it.error) {

--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -15,9 +15,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.AppConstants.EXTRA
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
@@ -68,49 +67,28 @@ class StarterActivity : AppActivity() {
                 waitingForService = true
                 moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@StarterActivity)
                 viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
-                window?.decorView?.postDelayed({
+                lifecycleScope.launch {
+                    delay(3000L)
                     if (!isFinishing) finish()
-                }, 3000)
+                }
             } else if (!waitingForService && finished) {
                 waitingForService = true
-                if (Shizuku.pingBinder() || ShizukuStateMachine.isRunning()) {
-                    moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@StarterActivity)
-                    viewModel.appendOutput("")
-                    viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
-                    window?.decorView?.postDelayed({
+                viewModel.appendOutput("")
+                viewModel.appendOutput("Waiting for service...")
+
+                lifecycleScope.launch {
+                    val running = ShizukuStateMachine.awaitRunning(12_000L)
+
+                    if (running) {
+                        moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@StarterActivity)
+                        viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
+                        delay(3000L)
                         if (!isFinishing) finish()
-                    }, 3000)
-                } else {
-                    viewModel.appendOutput("")
-                    viewModel.appendOutput("Waiting for service...")
-
-                    lifecycleScope.launch {
-                        var running = false
-                        val startTime = System.currentTimeMillis()
-                        while (!running && (System.currentTimeMillis() - startTime) < 12_000L) {
-                            if (Shizuku.pingBinder() || ShizukuStateMachine.isRunning()) {
-                                ShizukuStateMachine.set(ShizukuStateMachine.State.RUNNING)
-                                running = true
-                                break
-                            }
-                            withTimeoutOrNull(500L) {
-                                ShizukuStateMachine.asFlow().first { it == ShizukuStateMachine.State.RUNNING }
-                                running = true
-                            }
-                        }
-
-                        if (running) {
-                            moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@StarterActivity)
-                            viewModel.appendOutput("Service started, this window will be automatically closed in 3 seconds")
-                            window?.decorView?.postDelayed({
-                                if (!isFinishing) finish()
-                            }, 3000)
-                        } else {
-                            viewModel.appendOutput("")
-                            viewModel.appendOutput("✗ Timed out waiting for Shevery service to initialize.")
-                            viewModel.appendOutput("  The starter process completed, but the server binder was not received.")
-                            viewModel.appendOutput("  Please try starting again, or check background battery restrictions.")
-                        }
+                    } else {
+                        viewModel.appendOutput("")
+                        viewModel.appendOutput("✗ Timed out waiting for Shevery service to initialize.")
+                        viewModel.appendOutput("  The starter process completed, but the server binder was not received.")
+                        viewModel.appendOutput("  Please try starting again, or check background battery restrictions.")
                     }
                 }
             } else if (it.status == Status.ERROR) {

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -518,6 +518,8 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
         sendBinderToUserApp(binder, packageName, userId, true);
     }
 
+    private static final long[] NULL_PROVIDER_RETRY_BACKOFF_MS = {250L, 500L, 1000L, 1500L};
+
     static void sendBinderToUserApp(Binder binder, String packageName, int userId, boolean retry) {
         try {
             DeviceIdleControllerApis.addPowerSaveTempWhitelistApp(packageName, 30 * 1000, userId,
@@ -532,10 +534,19 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
         IBinder token = null;
 
         try {
-            provider = ActivityManagerApis.getContentProviderExternal(name, userId, token, name);
-            if (provider == null) {
-                LOGGER.e("provider is null %s %d", name, userId);
-                return;
+            for (int attempt = 0; ; attempt++) {
+                provider = ActivityManagerApis.getContentProviderExternal(name, userId, token, name);
+                if (provider != null) {
+                    break;
+                }
+                if (attempt >= NULL_PROVIDER_RETRY_BACKOFF_MS.length) {
+                    LOGGER.e("provider is null %s %d (gave up after %d attempts)", name, userId, attempt + 1);
+                    return;
+                }
+                long backoff = NULL_PROVIDER_RETRY_BACKOFF_MS[attempt];
+                LOGGER.w("provider is null %s %d, retrying in %dms (attempt %d/%d)",
+                        name, userId, backoff, attempt + 1, NULL_PROVIDER_RETRY_BACKOFF_MS.length + 1);
+                Thread.sleep(backoff);
             }
             if (!provider.asBinder().pingBinder()) {
                 LOGGER.e("provider is dead %s %d", name, userId);


### PR DESCRIPTION
### Objective

Resolve an issue where starting Shevery via Wireless Debugging or TCP 5555 occasionally becomes permanently stuck at `"Waiting for service..."`, forcing the user to exit and restart the server.

### Implementation

1. **ContentProvider Acquisition Backoff Retry (`ShizukuService.java`):**
   - When restarting adbd or switching debug modes, Android's `ActivityManagerService` can temporarily return `null` for `getContentProviderExternal()` during package/provider re-registration.
   - Added an exponential backoff retry loop (`{250L, 500L, 1000L, 1500L}`) matching `ServiceStarter.java`, ensuring the server daemon does not prematurely drop binder publication to Shevery.

2. **Replacement Binder Interception (`ShizukuManagerProvider.kt`):**
   - Intercepted `METHOD_SEND_BINDER` in `ShizukuManagerProvider.call()`.
   - If an incoming server binder arrives while the previous binder instance is still pingable or unlinking asynchronously (`!pingBinder() || getBinder() != newBinder`), the new binder is accepted and registered via `Shizuku.onBinderReceived()` rather than being silently ignored.
   - Dynamically falls back to `BuildConfig.APPLICATION_ID` instead of a hardcoded string when `context?.packageName` is null.

3. **Reactive Starter Watchdog & Centralized State Machine (`StarterActivity.kt`):**
   - Streamlined the starter watchdog using `ShizukuStateMachine.awaitRunning(12_000L)`, incorporating 0ms fast-path checks and reactive state flow observation without manual loops.
   - If the server binder does not arrive within 12 seconds, outputs a descriptive diagnostic message instructing the user to retry rather than hanging indefinitely.
   - Replaced UI message queue delays with `lifecycleScope`-aware coroutine `delay(3000L)` to cleanly dismiss the window without handler leaks.

### Testing

- [x] Compiled initial Release APK via GitHub Actions CI (Run #33944474068, 100% SUCCESS).
- [x] Compiled updated Release APK with maintainer review cleanups via GitHub Actions CI (Run #33962159678, 100% SUCCESS).
- [x] Verified zero compilation errors or new warnings across server and manager modules.

### Checklist

- [x] Code follows the existing Kotlin/Compose style.
- [x] Code compiles locally without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.

### Screenshots (if applicable)

N/A