### PR TITLE
feat(ui): clean up Home top bar, add Pull-to-Refresh, and relocate About to Settings

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -53,8 +53,9 @@ import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
@@ -77,6 +78,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -266,7 +268,6 @@ abstract class HomeActivity : AppActivity() {
                                         checkServerStatus()
                                         appsModel.load()
                                     },
-                                    onAbout = ::showAboutDialog,
                                     onStop = ::showStopDialog,
                                     onManageApps = { manageAppsLauncher.launch(Intent(this@HomeActivity, ApplicationManagementActivity::class.java)) },
                                     onTerminal = { startActivity(Intent(this@HomeActivity, ShellTutorialActivity::class.java)) },
@@ -815,7 +816,6 @@ private fun HomeScreen(
     isPrimaryUser: Boolean,
     isRooted: Boolean,
     onRefresh: () -> Unit,
-    onAbout: () -> Unit,
     onStop: () -> Unit,
     onManageApps: () -> Unit,
     onTerminal: () -> Unit,
@@ -844,7 +844,9 @@ private fun HomeScreen(
     val diagnostics = remember(status, grantedCount, localNetworkPermissionState) {
         buildDiagnostics(context, status, grantedCount, localNetworkPermissionState)
     }
-    var moreOpen by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    var isRefreshing by remember { mutableStateOf(false) }
+    val pullToRefreshState = rememberPullToRefreshState()
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
@@ -858,47 +860,6 @@ private fun HomeScreen(
                         overflow = TextOverflow.Ellipsis
                     )
                 },
-                actions = {
-                    IconButton(onClick = onRefresh) {
-                        ShizukuIcon(
-                            icon = R.drawable.ic_server_restart,
-                            contentDescription = stringResource(R.string.home_refresh)
-                        )
-                    }
-                    Box {
-                        IconButton(onClick = { moreOpen = true }) {
-                            ShizukuIcon(
-                                icon = R.drawable.ic_more_vert_24,
-                                contentDescription = stringResource(R.string.accessibility_more_options)
-                            )
-                        }
-                        DropdownMenu(
-                            expanded = moreOpen,
-                            onDismissRequest = { moreOpen = false }
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.action_stop)) },
-                                leadingIcon = {
-                                    ShizukuIcon(R.drawable.ic_close_24, contentDescription = null)
-                                },
-                                onClick = {
-                                    moreOpen = false
-                                    onStop()
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.action_about)) },
-                                leadingIcon = {
-                                    ShizukuIcon(R.drawable.ic_outline_info_24, contentDescription = null)
-                                },
-                                onClick = {
-                                    moreOpen = false
-                                    onAbout()
-                                }
-                            )
-                        }
-                    }
-                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface,
                     scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer
@@ -906,13 +867,30 @@ private fun HomeScreen(
             )
         }
     ) { innerPadding ->
-        LazyColumn(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding),
-            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 112.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(innerPadding)
         ) {
+            PullToRefreshBox(
+                modifier = Modifier.fillMaxSize(),
+                isRefreshing = isRefreshing,
+                onRefresh = {
+                    scope.launch {
+                        isRefreshing = true
+                        onRefresh()
+                        delay(500L)
+                        isRefreshing = false
+                    }
+                },
+                state = pullToRefreshState,
+                indicator = {}
+            ) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 112.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
             item {
                 StatusHero(
                     serviceResource = serviceResource,
@@ -1043,6 +1021,15 @@ private fun HomeScreen(
             }
         }
     }
+    PullToRefreshDefaults.LoadingIndicator(
+        state = pullToRefreshState,
+        isRefreshing = isRefreshing,
+        modifier = Modifier
+            .align(Alignment.TopCenter)
+            .padding(top = 8.dp)
+    )
+}
+}
 }
 
 @Composable

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import moe.shizuku.manager.about.AboutActivity
 import android.os.Build
 import android.text.TextUtils
 import androidx.appcompat.app.AppCompatDelegate
@@ -671,6 +672,24 @@ fun SettingsScreen() {
                     summary = stringResource(R.string.restore_summary),
                     onClick = {
                         restoreLauncher.launch(arrayOf("application/zip", "application/octet-stream"))
+                    }
+                )
+            }
+        }
+
+        item {
+            SettingsGroup(title = stringResource(R.string.action_about)) {
+                val versionName = remember {
+                    try {
+                        context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: ""
+                    } catch (e: Exception) { "" }
+                }
+                SettingsRow(
+                    icon = R.drawable.ic_outline_info_24,
+                    title = stringResource(R.string.app_name),
+                    summary = if (versionName.isNotBlank()) "v$versionName" else null,
+                    onClick = {
+                        context.startActivity(Intent(context, AboutActivity::class.java))
                     }
                 )
             }


### PR DESCRIPTION
### Objective & Reason for Changes

This PR modernizes the main screen header according to Material 3 Expressive guidelines, eliminates redundant controls, and resolves navigation inconsistencies:

1. **3-Dot Overflow Menu Anti-Pattern:**
   - The previous Home `TopAppBar` contained a 3-dot dropdown with only two items: *Stop Shevery* and *About*. Material 3 guidelines discourage using an overflow menu for 1–2 items when they can be placed in standard navigation locations or contextually.
   - *Stop Shevery* was 100% duplicate: the prominent `StatusHero` card right below the app bar already features a dedicated `FilledTonalButton` with "Stop" when the service is running. Furthermore, selecting "Stop Shevery" from the 3-dot menu while stopped only triggered a redundant *"Service already stopped"* toast.
   - *About* was hidden in this dropdown and completely absent from the dedicated **Settings** screen (`SettingsScreen.kt`), where users canonically expect to find version numbers, app updates, and developer links.

2. **Misleading Refresh Icon vs. Native Pull-to-Refresh:**
   - The top bar refresh action used `R.drawable.ic_server_restart` (a circular server reboot glyph), giving users the impression that tapping it would restart the server daemon, when it actually only refreshed local UI status and permission counts.
   - In modern Jetpack Compose Material 3 applications, content reloads are canonically handled via a swipe-down gesture rather than a static header button taking up top bar real estate.

---

### Implementation

1. **Pure Material 3 Home TopAppBar (`HomeActivity.kt`):**
   - Removed the 3-dot overflow menu and the misleading `ic_server_restart` icon button.
   - Cleaned up unused imports (`DropdownMenu`, `DropdownMenuItem`) and removed `onAbout` from the `HomeScreen` signature.
   - Preserved the contextual "Stop" action inside `StatusHero` (active only when the server is running).

2. **Native Material 3 Pull-to-Refresh (`HomeActivity.kt`):**
   - Wrapped `HomeScreen`'s `LazyColumn` inside `PullToRefreshBox` with `PullToRefreshDefaults.LoadingIndicator`.
   - Swiping down triggers `checkServerStatus()` and `appsModel.load()` with smooth 500ms debouncing and progress indicator alignment below the curved top bar.

3. **Canonical "About" Section in Settings (`SettingsScreen.kt`):**
   - Added an `action_about` `SettingsGroup` at the bottom of `SettingsScreen`.
   - Displays the app name, info icon (`ic_outline_info_24`), and live version name (`v<versionName>`).
   - Tapping the row opens `AboutActivity` directly.

---

### Testing

- [x] Compiled Release APK via GitHub Actions CI (Run #33964774953, 100% SUCCESS).
- [x] Verified zero compilation errors or new warnings across server and manager modules.

### Checklist

- [x] Code follows the existing Kotlin/Compose style.
- [x] Code compiles cleanly without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.