### PR TITLE
fix(dhizuku): drop ADB-TCP 5555 fallback from Dhizuku starter

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -376,45 +376,11 @@ private class ViewModel(context: Context, root: Boolean, dhizuku: Boolean, host:
                         appendLine("✓ Shevery binder verified.")
                         postResult()
                     } else {
-                        appendLine("Direct Dhizuku execution did not publish binder, attempting ADB TCP 5555 activation via Dhizuku...")
-                        var adbSuccess = false
-                        try {
-                            dhizukuService.enableAdb()
-                            val bound = dhizukuService.bindAdbTcp(AdbStarter.TCP_MODE_PORT)
-                            if (bound) {
-                                appendLine("✓ Port 5555 bound via Dhizuku. Connecting via ADB...")
-                                AdbStarter.start(
-                                    host = "127.0.0.1",
-                                    port = AdbStarter.TCP_MODE_PORT,
-                                    context = appContext,
-                                    listener = {
-                                        synchronized(outputLock) {
-                                            sb.append(String(it))
-                                        }
-                                        postResult()
-                                    },
-                                    log = {
-                                        appendLine(it)
-                                    }
-                                )
-                                if (waitForShizukuBinder()) {
-                                    appendLine("✓ Shevery binder verified via ADB 5555.")
-                                    adbSuccess = true
-                                    postResult()
-                                }
-                            } else {
-                                appendLine("✗ Failed to bind ADB to port 5555 via Dhizuku.")
-                            }
-                        } catch (adbEx: Exception) {
-                            appendLine("✗ ADB TCP activation via Dhizuku failed: ${adbEx.message}")
-                        }
-
-                        if (!adbSuccess) {
-                            appendLine("✗ Starter command completed, but Shevery service did not become available.")
-                            appendLine("  Direct Dhizuku startup can fail when the Device Owner context cannot provide the same shell/root environment as ADB or root.")
-                            appendLine("  Try starting with Wireless ADB or root, then copy diagnostics if this repeats.")
-                            postResult(DhizukuException("Dhizuku starter did not publish a Shevery binder"))
-                        }
+                        appendLine("✗ Starter command completed,but Shevery service did not become available.")
+                        appendLine("  Per README: start Shevery first by PC/OTG or Wireless Debugging, then use Dhizuku — \"Do not start Shevery via Dhizuku first.\"")
+                        appendLine("  Direct Dhizuku startup can fail when the Device Owner context cannot provide the same shell/root environment as ADB or root.")
+                        appendLine("  Try starting with Wireless ADB or root, then copy diagnostics if this repeats.")
+                        postResult(DhizukuException("Dhizuku starter did not publish a Shevery binder"))
                     }
                 } finally {
                     connection?.let { conn ->


### PR DESCRIPTION
## What

Removes the **ADB-TCP fallback** from the `Start (via Dhizuku)` path: when the direct Dhizuku command completes but doesn't publish a binder, the starter no longer tries `enableAdb()` → `bindAdbTcp(5555)` → `AdbStarter.start(127.0.0.1:5555)`. Dhizuku mode itself — toggle, direct `runCommand` path, binder wait, failure hints — **stays identical**. The one dead branch dies; the user now gets an honest, instant failure instead of a doomed ~10 s ADB attempt (+ global ADB setting mutation en route(.



## Why this stays — it's the project's own spec

From `README.md` (commit `0d79ff1`, "How Start (via Dhizuku( works"?, verbatim:

> First, you need to start Shevery **by PC/OTG or Wireless Debugging**.**
> **Do not start Shevery via Dhizuku first.***

The `Start (via Dhizuku)` button — and the ADB-TCP fallback on top — did exactly what that line says *not* to do: it tried to bootstrap the server via Dhizuku *alone*. We removed **only that contradiction** — 33 lines of the failed ADB attempt. Every other Dhizuku surface is untouched:

- `enableAdb()` / `bindAdbTcp()` **stay** in the AIDL — `HomeActivity`'s one-click TCP 5555 card uses Dhizuku-**then-root** (`com.topjohnwu.superuser`),which *can* establish the port,so that working feature is preserved..
- The failure now tells users the README rule before suggesting Wireless ADB/root..
- Net diff:+5/−39 in one file; no manifest,no strings,no API changes..



## Why the fallback could never work (code-verified(

Two independent investigations (subagents, reading the live code( agree with #153's own diagnosis::

1. The DO user-service runs **as the app's own uid** — `setprop service.adb.tcp.port` and `ctl.restart adbd` are SELinux-gated to shell/root/init.system_server. An app uid cannot start adbd,period — ADB also needs a pre-authorized RSA key or pairing passcode,which an app can't self-grant..
2. The Dhizuku-API provides **no shell/root backend by design** (unlike Shizuku-API's UID 2000/0 contract( — `libshizuku.so` only publishes a real privileged binder from UID 0 or 2000,neither of which the DHizuku user-service context provides. "Did not publish binder" was structural, not transient — the retry could never fix it..

Nothing in `AdbStarter` can fix that; it's architectural, not a bug. If the fallback is to be resurrected,it needs a *new feature design* (e.g. DO-driven **Wireless-ADB pairing** via Android's built-in flow, minus PC( — happy to spec that separately..



## Commits

- `5dfc79a` `fix(dhizuku): drop ADB-TCP 5555 fallback from Dhizuku starter` (+5/−39,`StarterActivity.kt`(



## Test plan

- CI/pod build passes..
- Device:with Dhizuku Mode enabled andno prior server:starter logs the ✗ + README hint **instantly** (no 5555 port appears;no 10 s ADB attempt;no global-setting mutation(. Direct-path success/failure behavior unchanged..
- `HomeActivity` "TCP 5555" one-click card unchanged (superuser-backed path unaffected(..



CC @LandonMoran — never merge without explicit approval,per standing convention.