### PR TITLE
fix(watchdog): resolve server process name mismatch in fallback force-stop

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -294,7 +294,7 @@ object WatchdogManager {
             val binder = Shizuku.getBinder() ?: return "binder was null"
             val service = IShizukuService.Stub.asInterface(binder)
             val process = service.newProcess(
-                arrayOf("sh", "-c", "for pid in $(pidof shevery_server 2>/dev/null); do kill -9 \"\$pid\"; done"),
+                arrayOf("sh", "-c", "for pid in $(pidof shizuku_server shevery_server 2>/dev/null); do kill -9 \"\$pid\"; done"),
                 null,
                 null
             )


### PR DESCRIPTION
### Objective
Fix the server stop action failing to terminate running server daemons due to a process name mismatch in `WatchdogManager.forceStopServerProcess`.

### Implementation
In commit `76a5a5e55294d9ffc79786228a7f933e895278c2`, `forceStopServerProcess` was modified to target `shevery_server`. However, the native starter (`manager/src/main/jni/starter.cpp:35`) still spawns the server daemon with `--nice-name=shizuku_server`.

Because `pidof shevery_server` returns empty, the fallback force-stop mechanism never terminates the running server, leaving stale daemons active across manager updates and causing version mismatch warnings (e.g., `running version 13.0, adb start again to update to version 13.9`).

This change updates the `pidof` query to inspect both `shizuku_server` and `shevery_server`:
```bash
for pid in $(pidof shizuku_server shevery_server 2>/dev/null); do kill -9 "$pid"; done
```
This ensures running daemons are properly terminated while preserving forward compatibility if the native daemon is renamed in the future.

### Testing
- [x] Compiled Release APK via GitHub Actions CI (Run [#34013384305](https://github.com/CodexofLost/shevery/actions/runs/34013384305): build passed in 6m48s).
- [x] Verified `pidof shizuku_server shevery_server` resolves the active daemon PID on Android 16 (ColorOS/OxygenOS).
- [x] Verified server process termination and clean binder reconnect upon app restart.

### Checklist
- [x] Code follows the existing Kotlin/Compose style.
- [x] Code compiles locally without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.

### Screenshots (if applicable)
N/A (backend process management fix)