### PR TITLE
fix(starter): resolve MaterialAlertDialogBuilder compiler error in StarterActivity

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -107,33 +107,6 @@ class StarterActivity : AppActivity() {
                         viewModel.appendOutput("  Please try starting again, or check background battery restrictions.")
                     }
                 }
-            } else if (it.status == Status.ERROR) {
-                var message = 0
-                when (it.error) {
-                    is AdbKeyException -> {
-                        message = R.string.adb_error_key_store
-                    }
-                    is NotRootedException -> {
-                        message = R.string.start_with_root_failed
-                    }
-                    is ConnectException -> {
-                        message = R.string.cannot_connect_port
-                    }
-                    is SSLProtocolException -> {
-                        message = R.string.adb_pair_required
-                    }
-                    is DhizukuException -> {
-                        // Already logged in the output
-                    }
-
-                }
-
-                if (message != 0) {
-                    MaterialAlertDialogBuilder(this)
-                        .setMessage(message)
-                        .setPositiveButton(android.R.string.ok, null)
-                        .show()
-                }
             }
         }
 


### PR DESCRIPTION
### Objective
Fix a Kotlin compilation error (`Unresolved reference 'MaterialAlertDialogBuilder'`) introduced during merge conflict resolution on `dev`.

### Implementation
During the merge of PR #152 and PR #158 into `dev`, a legacy error observer block referencing `MaterialAlertDialogBuilder` was accidentally retained in `StarterActivity.onCreate()`.

Error presentation in `StarterActivity` had already been migrated to a pure Jetpack Compose `AlertDialog` via `LaunchedEffect` in `setContent()` (PR #156 / #158), where `MaterialAlertDialogBuilder` imports were intentionally removed.

This change removes the redundant legacy block from `onCreate()`, restoring clean compilation and delegating error presentation entirely to the Compose `AlertDialog`.

### Testing
- [x] Verified `StarterActivity` Compose `LaunchedEffect` properly captures error states (`AdbKeyException`, `NotRootedException`, etc.).
- [x] Triggered CI build workflow [Run #34025139522](https://github.com/CodexofLost/shevery/actions/runs/34025139522).

### Checklist
- [x] Code follows the existing Kotlin/Compose style.
- [x] Code compiles locally without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.

### Screenshots (if applicable)
N/A (compiler fix and dead code cleanup)