### PR TITLE
fix(auth): restore INTERACT_ACROSS_USERS_FULL guard on RequestPermissionActivity

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -157,7 +157,7 @@
             android:directBootAware="true"
             android:excludeFromRecents="true"
             android:exported="true"
-            android:permission="moe.shizuku.manager.permission.MANAGER"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL"
             android:theme="@style/GrantPermissions">
             <intent-filter>
                 <action android:name="${applicationId}.intent.action.REQUEST_PERMISSION" />


### PR DESCRIPTION
### Objective
Restore the permission prompt dialog for client applications by reinstating `android.permission.INTERACT_ACROSS_USERS_FULL` as the component guard on `RequestPermissionActivity`.

In Shevery `r32-beta1` (commit `76a5a5e5` via PR #105), `RequestPermissionActivity` had its guarding permission replaced with `moe.shizuku.manager.permission.MANAGER`. Because `moe.shizuku.manager.permission.MANAGER` has `protectionLevel="signature"`, Android's `ActivityTaskManager` rejects any caller not signed with Shevery's private signing key.

When a client application requests permission, `ShizukuService` (running inside `app_process` as ADB `shell` UID 2000) calls:
```java
ActivityManagerApis.startActivityNoThrow(intent, null, isWorkProfileUser ? 0 : userId);
```
Under ADB/Wireless mode, Android blocks the launch with `SecurityException: Permission Denial: starting Intent requires moe.shizuku.manager.permission.MANAGER`. Because `startActivityNoThrow` catches and silences the exception, the activity never launches, the dialog never renders, and client applications hang until timing out.

### Implementation
Reverted the permission attribute on `.authorization.RequestPermissionActivity` in `manager/src/main/AndroidManifest.xml` back to `android.permission.INTERACT_ACROSS_USERS_FULL`:
- Held by system `shell` (UID 2000) and `root` (UID 0), allowing `ShizukuService` to start the authorization dialog.
- Not held by standard 3rd-party apps (UID 10000+), maintaining protection against direct intent spoofing from unprivileged applications.

### Testing
- [x] Compiled via GitHub Actions Cloud Build ([Run #34037113724](https://github.com/CodexofLost/shevery/actions/runs/34037113724)).
- [x] Inspected binary `AndroidManifest.xml` via `aapt2 dump xmltree` on the compiled APK:
  ```text
  E: activity (line=153)
    A: android:name="moe.shizuku.manager.authorization.RequestPermissionActivity"
    A: android:permission="android.permission.INTERACT_ACROSS_USERS_FULL"
    A: android:exported=true
  ```
- [x] Verified permission prompt dialogs appear immediately when client applications request access.

### Checklist
- [x] Code follows the existing Kotlin/Compose style.
- [x] Code compiles locally without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.

### Screenshots (if applicable)
N/A (manifest security declaration fix; no layout modifications).
