### PR TITLE
refactor(ui): migrate activity dialogs to Compose AlertDialog

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/authorization/RequestPermissionActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/authorization/RequestPermissionActivity.kt
@@ -3,28 +3,26 @@ package moe.shizuku.manager.authorization
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.text.method.LinkMovementMethod
-import android.widget.TextView
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AlertDialog as AppCompatAlertDialog
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import androidx.compose.ui.unit.dp
 import moe.shizuku.manager.Helps
 import moe.shizuku.manager.R
 import moe.shizuku.manager.app.AppActivity
-import moe.shizuku.manager.ktx.toHtml
 import moe.shizuku.manager.ui.compose.ShizukuExpressiveTheme
 import moe.shizuku.manager.ui.compose.htmlToPlainText
+import moe.shizuku.manager.utils.CustomTabsHelper
 import moe.shizuku.manager.utils.Logger.LOGGER
-import rikka.core.res.resolveColor
-import rikka.html.text.HtmlCompat
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuApiConstants.REQUEST_PERMISSION_REPLY_ALLOWED
 import rikka.shizuku.ShizukuApiConstants.REQUEST_PERMISSION_REPLY_IS_ONETIME
@@ -47,22 +45,52 @@ class RequestPermissionActivity : AppActivity() {
         val permission = Shizuku.checkRemotePermission("android.permission.GRANT_RUNTIME_PERMISSIONS") == PackageManager.PERMISSION_GRANTED
         if (permission) return true
 
-        val icon = getDrawable(R.drawable.ic_system_icon)
-        icon?.setTint(theme.resolveColor(android.R.attr.colorAccent))
-
-        val dialog = MaterialAlertDialogBuilder(this)
-                .setIcon(icon)
-                .setTitle("Shizuku: ${getString(R.string.app_management_dialog_adb_is_limited_title)}")
-                .setMessage(getString(R.string.app_management_dialog_adb_is_limited_message, Helps.ADB.get()).toHtml(HtmlCompat.FROM_HTML_OPTION_TRIM_WHITESPACE))
-                .setPositiveButton(android.R.string.ok, null)
-                .setOnDismissListener { finish() }
-                .create()
-        dialog.setOnShowListener {
-            (it as AppCompatAlertDialog).findViewById<TextView>(android.R.id.message)?.movementMethod = LinkMovementMethod.getInstance()
-        }
-        try {
-            dialog.show()
-        } catch (ignored: Throwable) {
+        setContent {
+            ShizukuExpressiveTheme {
+                AlertDialog(
+                    onDismissRequest = { finish() },
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_system_icon),
+                            contentDescription = null
+                        )
+                    },
+                    title = {
+                        Text("${stringResource(R.string.app_name)}: ${stringResource(R.string.app_management_dialog_adb_is_limited_title)}")
+                    },
+                    text = {
+                        Text(
+                            text = htmlToPlainText(
+                                getString(
+                                    R.string.app_management_dialog_adb_is_limited_message,
+                                    Helps.ADB.get()
+                                )
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    },
+                    confirmButton = {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedButton(
+                                onClick = {
+                                    CustomTabsHelper.launchUrlOrCopy(
+                                        this@RequestPermissionActivity,
+                                        Helps.ADB.get()
+                                    )
+                                }
+                            ) {
+                                Text(stringResource(R.string.home_adb_button_view_help))
+                            }
+                            Button(onClick = { finish() }) {
+                                Text(stringResource(android.R.string.ok))
+                            }
+                        }
+                    },
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shape = MaterialTheme.shapes.extraLarge
+                )
+            }
         }
         return false
     }

--- a/manager/src/main/java/moe/shizuku/manager/legacy/LegacyIsNotSupportedActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/legacy/LegacyIsNotSupportedActivity.kt
@@ -4,12 +4,23 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
 import moe.shizuku.manager.app.AppActivity
-import moe.shizuku.manager.ktx.toHtml
-import rikka.html.text.HtmlCompat
+import moe.shizuku.manager.ui.compose.ShizukuExpressiveTheme
+import moe.shizuku.manager.ui.compose.htmlToPlainText
 
 class LegacyIsNotSupportedActivity : AppActivity() {
 
@@ -50,32 +61,72 @@ class LegacyIsNotSupportedActivity : AppActivity() {
         }
 
         val v3Support = ai.metaData?.getBoolean("moe.shizuku.client.V3_SUPPORT") == true
-        if (v3Support) {
-            MaterialAlertDialogBuilder(this)
-                    .setTitle(getString(R.string.dialog_requesting_legacy_title, label))
-                    .setMessage(getString(R.string.dialog_requesting_legacy_message, label).toHtml(HtmlCompat.FROM_HTML_OPTION_TRIM_WHITESPACE))
-                    .setPositiveButton(android.R.string.ok, null)
-                    .setNeutralButton(R.string.dialog_requesting_legacy_button_open_shizuku) { _, _ ->
-                        startActivity(Intent(this, MainActivity::class.java)
-                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
-                    }
-                    .setOnDismissListener {
+
+        setContent {
+            ShizukuExpressiveTheme {
+                AlertDialog(
+                    onDismissRequest = {
                         setResult(RESULT_ERROR)
                         finish()
-                    }
-                    .setCancelable(false)
-                    .show()
-        } else {
-            MaterialAlertDialogBuilder(this)
-                    .setTitle(getString(R.string.dialog_legacy_not_support_title, label))
-                    .setMessage(getString(R.string.dialog_legacy_not_support_message, label).toHtml(HtmlCompat.FROM_HTML_OPTION_TRIM_WHITESPACE))
-                    .setPositiveButton(android.R.string.ok, null)
-                    .setOnDismissListener {
-                        setResult(RESULT_ERROR)
-                        finish()
-                    }
-                    .setCancelable(false)
-                    .show()
+                    },
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_system_icon),
+                            contentDescription = null
+                        )
+                    },
+                    title = {
+                        Text(
+                            text = if (v3Support) {
+                                stringResource(R.string.dialog_requesting_legacy_title, label)
+                            } else {
+                                stringResource(R.string.dialog_legacy_not_support_title, label)
+                            }
+                        )
+                    },
+                    text = {
+                        Text(
+                            text = htmlToPlainText(
+                                if (v3Support) {
+                                    getString(R.string.dialog_requesting_legacy_message, label)
+                                } else {
+                                    getString(R.string.dialog_legacy_not_support_message, label)
+                                }
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    },
+                    confirmButton = {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            if (v3Support) {
+                                OutlinedButton(
+                                    onClick = {
+                                        startActivity(
+                                            Intent(this@LegacyIsNotSupportedActivity, MainActivity::class.java)
+                                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                        )
+                                        setResult(RESULT_ERROR)
+                                        finish()
+                                    }
+                                ) {
+                                    Text(stringResource(R.string.dialog_requesting_legacy_button_open_shizuku))
+                                }
+                            }
+                            Button(
+                                onClick = {
+                                    setResult(RESULT_ERROR)
+                                    finish()
+                                }
+                            ) {
+                                Text(stringResource(android.R.string.ok))
+                            }
+                        }
+                    },
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shape = MaterialTheme.shapes.extraLarge
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
### Objective
Migrate legacy `MaterialAlertDialogBuilder` implementations and eliminate `findViewById` in `RequestPermissionActivity` and `LegacyIsNotSupportedActivity` in favor of pure Jetpack Compose `AlertDialog` styled with Material 3 Expressive tokens.

### Implementation
1. **`RequestPermissionActivity.kt`**:
   - Replaced `checkSelfPermission()`'s legacy `MaterialAlertDialogBuilder` and `findViewById<TextView>` with a pure Compose `AlertDialog`.
   - Utilizes Material 3 Expressive styling (`surfaceContainerHigh`, 28dp `extraLarge` shape) and standard `CustomTabsHelper.launchUrlOrCopy` for the "View Help" button.
2. **`LegacyIsNotSupportedActivity.kt`**:
   - Replaced the legacy V3 authorization dialog with pure Jetpack Compose `AlertDialog`.
   - Preserves all original `RESULT_ERROR`/`RESULT_CANCELED` semantics and "Open Shevery" launcher intent.
3. **Zero `findViewById`**:
   - Completely eliminates the last remaining `findViewById` usages in the application.

### Testing
- [x] Compiled Release/Debug APK via GitHub Actions Cloud Build ([Run #34038993050](https://github.com/CodexofLost/shevery/actions/runs/34038993050)).
- [x] Verified Compose theme and layout behavior in both light and dark mode.

### Checklist
- [x] Code follows the existing Kotlin/Compose style.
- [x] Code compiles locally without new warnings.
- [x] No unnecessary third-party dependencies were introduced.
- [x] Commits are logical and well-described.

### Screenshots (if applicable)
N/A (Dialog layout modernization aligned with M3 Expressive design tokens).
