### PR TITLE
fix(starter): pre-warm ShizukuManagerProvider to resolve 'Waiting for service...' timeout

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/starter/StarterActivity.kt
@@ -3,6 +3,7 @@
 package moe.shizuku.manager.starter
 
 import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.compose.setContent
@@ -93,6 +94,9 @@ class StarterActivity : AppActivity() {
                 viewModel.appendOutput("Waiting for service...")
 
                 lifecycleScope.launch {
+                    runCatching {
+                        contentResolver.getType(Uri.parse("content://$packageName.shizuku"))
+                    }
                     val running = ShizukuStateMachine.awaitRunning(12_000L)
 
                     if (running) {
@@ -228,6 +232,7 @@ private class ViewModel(context: Context, root: Boolean, dhizuku: Boolean, host:
     val output = _output as LiveData<Resource<String>>
 
     init {
+        prewarmManagerProvider()
         try {
             when {
                 dhizuku -> startDhizuku(context)
@@ -236,6 +241,13 @@ private class ViewModel(context: Context, root: Boolean, dhizuku: Boolean, host:
             }
         } catch (e: Throwable) {
             postResult(e)
+        }
+    }
+
+    private fun prewarmManagerProvider() {
+        runCatching {
+            val uri = Uri.parse("content://${appContext.packageName}.shizuku")
+            appContext.contentResolver.getType(uri)
         }
     }
 


### PR DESCRIPTION
### Objective

Resolve an issue where starting Shevery via Wireless ADB, TCP 5555, or Root occasionally times out at `Waiting for service...` (`Timed out waiting for Shevery service to initialize. The starter process completed, but the server binder was not received`).

### Root Cause

When the starter daemon spawns `shizuku_server`, the server immediately calls `ActivityManagerApis.getContentProviderExternal("com.hamondev.shevery.shizuku", userId, ...)`. During cold application startup or background process re-registration, Android's `ActivityManagerService` (AMS) may not yet have initialized and cached the `ContentProviderRecord` in its provider map, causing `getContentProviderExternal()` to return `null`. After its retry window elapses, the server gives up on binder delivery. The server process continues running, but the manager never receives the binder token, causing `StarterActivity` to time out after 12 seconds.

### Implementation

1. **Client-Side Provider Pre-Warming (`StarterActivity.kt`):**
   - Added `prewarmManagerProvider()` in `StarterActivity.ViewModel.init` prior to invoking `startAdb`, `startRoot`, or `startDhizuku`.
   - Touches `contentResolver.getType(Uri.parse("content://${appContext.packageName}.shizuku"))` to force AMS to instantiate, publish, and cache `ShizukuManagerProvider` in its active provider table before `shizuku_server` executes.
   - Guarded with `runCatching` for safe, zero-side-effect execution.
2. **Post-Starter Provider Touch (`StarterActivity.kt`):**
   - Re-touches the provider in `StarterActivity.onCreate` upon starter process completion (`info: shizuku_starter exit with 0`) immediately prior to entering `ShizukuStateMachine.awaitRunning(12_000L)`.
3. **Preserve Server Contracts:**
   - Leaves `NULL_PROVIDER_RETRY_BACKOFF_MS` in `ShizukuService.java` completely untouched, maintaining full backward compatibility with PR #152.

### Testing

- [✓] Compiled locally via `fast-gradlew :manager:compileDebugKotlin` with zero errors (BUILD SUCCESSFUL).
- [✓] Verified clean rebase onto latest `upstream/dev` (commit `749bf4dd`).
- [✓] Verified zero file collisions with open PR #164 and PR #165.

### Checklist

- [✓] Code follows Kotlin conventions and Ponytail anti-bloat principles (+12 lines, minimal footprint).
- [✓] Code compiles cleanly without warnings.
- [✓] No new third-party dependencies introduced.