### PR TITLE
fix(settings): restore missing Accessibility Manager entry in Settings

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -62,6 +62,7 @@ import moe.shizuku.manager.app.ThemeHelper
 import moe.shizuku.manager.app.ThemeHelper.KEY_BLACK_NIGHT_THEME
 import moe.shizuku.manager.app.ThemeHelper.KEY_USE_SYSTEM_COLOR
 import moe.shizuku.manager.ktx.setComponentEnabled
+import moe.shizuku.manager.accessibility.AccessibilityManagerActivity
 import moe.shizuku.manager.compat.StubManager
 import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.manager.module.update.AppUpdateSettingsGroup
@@ -648,6 +649,14 @@ fun SettingsScreen() {
 
         item {
             SettingsGroup(title = stringResource(R.string.settings_sections_title)) {
+                SectionHeader(stringResource(R.string.accessibility_manager_lab_group))
+                SettingsRow(
+                    icon = R.drawable.ic_system_icon,
+                    title = stringResource(R.string.accessibility_manager_lab_title),
+                    summary = stringResource(R.string.accessibility_manager_lab_summary),
+                    onClick = { context.startActivity(Intent(context, AccessibilityManagerActivity::class.java)) }
+                )
+                GroupDivider()
                 SectionHeader(stringResource(R.string.lab_features_title))
                 SettingsRow(
                     icon = R.drawable.ic_settings_outline_24dp,


### PR DESCRIPTION
## What```diff-user-visible change — **Accessibility Manager** card missing from **Settings → sections** (,reported missing in the Telegram group(. Internal code (activity, daemon, keep-alive store( was always intact;the Settings launcher row was dropped.\n\n## Root cause\n`c1ff4cc` (feat(settings): hide root boot toggle...\, cherry-pick of PRs #123/#124/#125( rewrote `SettingsScreen.kt` against an older base, dropping the Accessibility Manager row \+ its import — collateral from the `09fd908` promotion (Lab Features → main settings(.\n\n## Change\nRestores the two pieces from `09fd908` verbatim:\n- `import moe.shizuku.manager.accessibility.AccessibilityManagerActivity`\n- `SettingsRow` → `startActivity(AccessibilityManagerActivity)` in the sections group, before Lab Features, with `SectionHeader(accessibility_manager_lab_group)` + `GroupDivider`\n\nVerified: activity class, daemon, keep-alive store,, all `accessibility_manager_*` strings (incl. lab group/title/summary(, `ic_system_icon` drawable,, manifest intent-filter all present on dev — only the launcher row was missing.\n\nNo other regressions found: the only other casualty of that cherry-pick (the `shevery_update_*` strings( was already restored by PR #130.\n\n## Test\nNot run locally — UI-only change mirroring a previously-merged, known-good block; CI builds will validate.