### PR TITLE
fix(app): status bar icons invisible in dark mode

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
@@ -14,8 +14,8 @@ abstract class AppActivity : MaterialActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+            statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isNavigationBarContrastEnforced = false


### PR DESCRIPTION
## What
In dark mode the status bar looks dark because the icon contrast was hard-coded for a light surface.

## Why
`AppActivity.onCreate()` called `enableEdgeToEdge(` with `SystemBarStyle.light(...)` for both bars — which tells Android 'the bar sits on a light background, use **dark** icons' — for **every** theme, including dark. Dark icons on dark background = invisible status bar.

## Fix
Switch both bars to `SystemBarStyle.auto(TRANSPARENT, TRANSPARENT)`,which picks the icon contrast from the current night-mode configuration: dark icons in light mode (unchanged(, light icons in dark mode. Covers every Activity since all extend `AppActivity`. No behavior change in light mode.

Closes the reported dark-mode status bar issue.