### PR TITLE
fix(update): keep home card update in sync with live checks

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/about/AboutActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/about/AboutActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.BuildConfig
+import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.manager.module.update.SheveryAppUpdateDialog
 import moe.shizuku.manager.module.update.SheveryAppUpdateResult
 import moe.shizuku.manager.module.update.SheveryUpdateChecker
@@ -82,7 +83,22 @@ class AboutActivity : AppActivity() {
                                 onClick = {
                                     scope.launch {
                                         isCheckingUpdate = true
-                                        appUpdateResult = SheveryUpdateChecker.getInstance().checkAppUpdate(this@AboutActivity)
+                                        val result = SheveryUpdateChecker.getInstance().checkAppUpdate(this@AboutActivity)
+                                        // Keep the home card in sync: refresh pending update on a live check,
+                                        // and clear it once no newer release exists (so it never advertises an old version.
+
+                                        if (result.error == null) {
+                                            if (result.hasUpdate && result.downloadUrl != null) {
+                                                ModuleSettings.setPendingUpdate(
+                                                    version = result.latestVersion ?: "",
+                                                    url = result.downloadUrl ?: "",
+                                                    detectedAt = System.currentTimeMillis()
+                                                )
+                                            } else {
+                                                ModuleSettings.clearPendingUpdate()
+                                            }
+                                        }
+                                        appUpdateResult = result
                                         isCheckingUpdate = false
                                     }
                                 }

--- a/manager/src/main/java/moe/shizuku/manager/module/update/SheveryUpdateCheckWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/SheveryUpdateCheckWorker.kt
@@ -50,6 +50,10 @@ class SheveryUpdateCheckWorker(
                     url = result.downloadUrl ?: "",
                     detectedAt = now
                 )
+            } else {
+                // On latest (or no release): drop any stale pending update so the home card
+                // does not keep advertising an old version after a newer one landed or was installed.
+                moe.shizuku.manager.module.ModuleSettings.clearPendingUpdate()
             }
             Result.success()
         } catch (e: IOException) {


### PR DESCRIPTION
## Problem
The home update card advertised the **last background-detected** version — it was written only by the throttled periodic worker and **never refreshed or cleared**. Meanwhile the About screen's manual check hits GitHub live — so About popped the newest version while home still showed the previous one.

Root causes:
1. `clearPendingUpdate()` existed but was **dead code** — nichts ever called it. Once a pending update landed (or the installed version caught up(,the card stayed indefinitely, even surviving app updates (Android preserves app data on APK updates(.
2. About's live check threw the result away — never wrote it back to the shared pending state.



## Fix
Every successful check now **writes through** to the pending-update state:
- `SheveryUpdateCheckWorker` (periodic(: newer release → refresh pending; **no newer release → clear pending** so the card disappears instead of advertising an old version.
- `AboutActivity` (manual(: same write-through right after its live check — so the home card (and update settings row( immediately reflect what About found.


Errors (`result.error != null`: HTTP/rate-limit/network( leave the pending state untouched — no false clears on transient failures.

## Testing
- Needs device test: open About → check update → return Home → card should show the same (newest( version (or disappear if already on latest(.
- CI build runsin progress.

Also fixes the update settings card (`AppUpdateSettingsGroup`( which reads the same pending state.