### PR TITLE
feat(update): in-app APK download + PackageInstaller install

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         tools:ignore="ProtectedPermissions" />
     <!-- Network state checks (matches DJG reference) -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <!-- Prevent the OS from killing Shevery's foreground services on boot (matches DJG reference) -->
     <uses-permission
         android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"

--- a/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateDownloader.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateDownloader.kt
@@ -1,0 +1,65 @@
+package moe.shizuku.manager.module.update
+
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Downloads the Shevery update APK in-app so the install session can stream it.
+ *
+ * This mirrors the way MorpheApp's manager pulls release assets (direct stream +
+ * progress), without their JSON metadata layer: SheveryUpdateChecker already
+ * locates the release reliably, so this only has to fetch the bytes.
+ */
+object AppUpdateDownloader {
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS) // per-chunk timeout — the APK streams;60s is plenty between chunks
+        .build()
+
+    /**
+     * Downloads [url] into [targetFile]. Any partial download is deleted on failure,
+     * and a stale file from a previous attempt is removed up front. Progress callbacks
+     * fire with bytes-read so far + total when the server sent a Content-Length.
+     */
+
+    suspend fun downloadToFile(
+        url: String,
+        targetFile: File,
+        onProgress: (bytesRead: Long, contentLength: Long?) -> Unit
+    ) = withContext(Dispatchers.IO) {
+        targetFile.delete()
+        try {
+            val request = Request.Builder().url(url).build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("HTTP ${response.code}: ${response.message}")
+                }
+                val body = response.body ?: throw IOException("Empty response body")
+                val total = body.contentLength().takeIf { it > 0 }
+                body.byteStream().use { input ->
+                    targetFile.outputStream().use { output ->
+                        val buffer = ByteArray(64 * 1024)
+                        var read = 0L
+                        while (true) {
+                            val n = input.read(buffer)
+                            if (n < 0) break
+                            output.write(buffer, 0, n)
+                            read += n
+                            onProgress(read, total)
+                        }
+                        output.flush()
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            targetFile.delete()
+            throw e
+        }
+    }
+}

--- a/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateInstaller.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateInstaller.kt
@@ -1,0 +1,143 @@
+package moe.shizuku.manager.module.update
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.os.Process
+import androidx.core.content.ContextCompat
+import java.io.File
+import kotlin.coroutines.resume
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Streams the downloaded update APK into a [PackageInstaller] session — the same
+ * in-app install flow MorpheApp's manager uses for its own updates(.
+ *
+ * No Shizuku silent path: Shevery is the manager itself, not a Shizuku client of its
+ * own server, so athe silently-install route isn't naturally available. The system
+ * confirm dialog (which is normal for a self-update) is always shown.
+ If the session
+ * install cannot run for any reason, the caller falls back to opening the download
+ * URL in the browser — athe pre-in-app behavior — so the user is never stranded.
+
+ * The status broadcast is delivered to a receiver registered programmatically; if the
+ * process is replaced before athe final status arrives (i.e. the user confirmed(, that
+ * broadcast is simply dropped — the install itself is owned by the system and carries on
+ * regardless, so nothing depends on us surviving.
+
+ * @param apkFile APK staged by [AppUpdateDownloader] (deleted by the caller after success(.
+ */
+object AppUpdateInstaller {
+
+    private const val ACTION_INSTALL_STATUS = "moe.shizuku.manager.action.APP_UPDATE_INSTALL_STATUS"
+    private const val INSTALL_TIMEOUT_MINUTES = 5L
+
+    sealed interface Result {
+        /** Install session is committed; the system confirm dialog is (about to be( shown. */
+        data class UserActionRequired(val confirmIntent: Intent?): Result
+        /** Install finished without needing user action (rare — mostly post-process-death(;nothing to do. */
+        data class Success(val statusCode: Int): Result
+        /** Session failed or timed out; caller should offer the browser fallback. */
+        data class Failed(val statusCode: Int?, val message: String): Result
+    }
+
+    suspend fun install(context: Context, apkFile: File): Result = withContext(Dispatchers.IO) {
+        val appContext = context.applicationContext ?: context
+        val pm = appContext.packageManager
+        val sessionId: Int
+        try {
+            val params = PackageInstaller.SessionParams(
+                            PackageInstaller.SessionParams.MODE_FULL_INSTALL,
+                        ).apply {
+                            setOriginatingUid(Process.myUid())
+                        }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // 34: this package may replace itself
+                params.setRequestUpdateOwnership(true)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) { // 31: always surface the explicit user confirm
+                params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_REQUIRED)
+            }
+            sessionId = pm.packageInstaller.createSession(params)
+            val session = pm.packageInstaller.openSession(sessionId)
+            try {
+                apkFile.inputStream().use { input ->
+                    val output = session.openWrite("base.apk", 0, apkFile.length() )
+                    input.copyTo(output, 64 * 1024)
+                    session.fsync(output)
+                    output.close()
+                }
+                session.commit(commitIntent(appContext, sessionId).intentSender)
+            } finally {
+                session.close()
+            }
+        } catch (e: Exception) {
+            return@withContext Result.Failed(null, e.message ?: e.javaClass.simpleName)
+        }
+        awaitStatus(appContext, sessionId)
+    }
+
+    /** The broadcast is targeted at our own package so no other receiver can race us. */
+    private fun commitIntent(context: Context, sessionId: Int): PendingIntent {
+        val intent = Intent(ACTION_INSTALL_STATUS).setPackage(context.packageName)
+        return PendingIntent.getBroadcast(
+            context,
+            sessionId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        )
+    }
+
+    private suspend fun awaitStatus(context: Context, sessionId: Int): Result = withContext(Dispatchers.Main.immediate) {
+        withTimeout(INSTALL_TIMEOUT_MINUTES * 60 * 1000) {
+            suspendCancellableCoroutine { cont ->
+                val receiver = object : BroadcastReceiver() {
+                    override fun onReceive(ctx: Context?, intent: Intent?) {
+                        if (intent?.action != ACTION_INSTALL_STATUS) return
+                        val status = intent.getIntExtra(
+                            PackageInstaller.EXTRA_STATUS,
+                            PackageInstaller.STATUS_FAILURE
+                        )
+                        when (status) {
+                            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                                val confirm = confirmIntent(intent)
+                                if (cont.isActive) cont.resume(Result.UserActionRequired(confirm))
+                            }
+                            PackageInstaller.STATUS_SUCCESS -> {
+                                if (cont.isActive) cont.resume(Result.Success(status))
+                            }
+                            else -> {
+                                val msg = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                                if (cont.isActive) {
+                                    cont.resume(Result.Failed(status, msg ?: "install_status_$status"))
+                                }
+                            }
+                        }
+                        runCatching { context.unregisterReceiver(this) }
+                    }
+                }
+                val filter = IntentFilter(ACTION_INSTALL_STATUS)
+                val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+ // 33: implicit broadcast from the system install dialog
+                    ContextCompat.RECEIVER_NOT_EXPORTED
+                } else {
+                    0
+                }
+                ContextCompat.registerReceiver(context, receiver, filter, flags)
+                cont.invokeOnCancellation { runCatching { context.unregisterReceiver(receiver) } }
+            }
+        }
+    }
+
+    private fun confirmIntent(intent: Intent): Intent? {
+            // The pre-populated user-action intent rides in Intent.EXTRA_INTENT (CommonsWare
+            // documents this): EXTRA_STATUS_PENDING_USER_ACTION has never been public SDK.
+            return intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        }
+}

--- a/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,6 +33,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import android.content.Intent
 import androidx.compose.material3.Icon
@@ -165,11 +168,11 @@ fun AppUpdateSettingsGroup() {
         AlertDialog(
             onDismissRequest = { isCheckingAppUpdate = false },
             title = { Text(stringResource(R.string.shevery_update_check_title)) },
-            text = {
+text = {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    modifier = Modifier.padding(vertical =  8.dp),
                 ) {
                     LoadingIndicator(modifier = Modifier.size(28.dp))
                     Text(stringResource(R.string.shevery_update_checking))
@@ -282,82 +285,221 @@ private fun UpdateFrequencyDropdownForApp(
     }
 }
 
+private enum class AppUpdatePhase { Idle, Downloading, Installing, Failed }
+
 @Composable
 internal fun SheveryAppUpdateDialog(
     result: SheveryAppUpdateResult,
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val apkFile = remember { File(context.cacheDir, "shevery-app-update.apk") }
+
+    var phase by remember(result) { mutableStateOf(AppUpdatePhase.Idle) }
+    var progress by remember(result) { mutableStateOf(-1f) } // -1 = unknown length (indeterminate)
+    var errorMessage by remember(result) { mutableStateOf<String?>(null) }
+
+    fun startDownload() {
+        scope.launch {
+            phase = AppUpdatePhase.Downloading
+            progress = -1f
+            errorMessage = null
+            try {
+                AppUpdateDownloader.downloadToFile(
+                    url = result.downloadUrl!!,
+                    targetFile = apkFile,
+                    onProgress = { read, total ->
+                        progress = total?.takeIf { it > 0 }?.let { read.toFloat() / it } ?: -1f
+                    }
+                )
+                phase = AppUpdatePhase.Installing
+                when (val outcome = AppUpdateInstaller.install(context.applicationContext, apkFile)) {
+
+                    is AppUpdateInstaller.Result.UserActionRequired -> {
+                        outcome.confirmIntent?.let { confirm ->
+                            runCatching {
+                                context.startActivity(confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                            }
+                        }
+                        onDismiss()
+                    }
+                    is AppUpdateInstaller.Result.Success -> {
+                        runCatching {
+                            android.widget.Toast.makeText(
+                                context, R.string.shevery_update_install_success,
+                                android.widget.Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                        onDismiss()
+                    }
+                    is AppUpdateInstaller.Result.Failed -> {
+                        apkFile.delete()
+                        phase = AppUpdatePhase.Failed
+                        errorMessage = outcome.message
+                    }
+                }
+            } catch (e: CancellationException) {
+                apkFile.delete()
+                throw e
+            } catch (e: Exception) {
+                apkFile.delete()
+                phase = AppUpdatePhase.Failed
+                errorMessage = e.message ?: e.javaClass.simpleName
+            }
+        }
+    }
 
     AlertDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            if (phase != AppUpdatePhase.Installing) onDismiss()
+        },
         title = {
-            Text(
-                text = if (result.hasUpdate) {
-                    stringResource(R.string.shevery_update_available_title)
+            when (phase) {
+                AppUpdatePhase.Idle -> if (result.hasUpdate) {
+                    Text(stringResource(R.string.shevery_update_available_title))
                 } else if (result.error != null) {
-                    stringResource(R.string.shevery_update_check_failed, result.error)
+                    Text(stringResource(R.string.shevery_update_check_failed, result.error))
                 } else {
-                    stringResource(R.string.shevery_update_up_to_date, result.currentVersion)
+                    Text(stringResource(R.string.shevery_update_up_to_date, result.currentVersion))
                 }
-            )
+                AppUpdatePhase.Downloading -> Text(stringResource(R.string.shevery_update_downloading_title))
+                AppUpdatePhase.Installing -> Text(stringResource(R.string.shevery_update_installing))
+                AppUpdatePhase.Failed -> Text(stringResource(R.string.shevery_update_install_failed_title))
+            }
         },
         text = {
-            if (result.hasUpdate && result.latestVersion != null) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                        text = stringResource(
-                            R.string.shevery_update_available_msg,
-                            result.latestVersion,
-                            result.currentVersion
-                        ),
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                    if (!result.releaseNotes.isNullOrBlank()) {
-                        Text(
-                            text = result.releaseNotes.take(400).let {
-                                if (result.releaseNotes.length > 400) "$it…" else it
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    if (result.isPreRelease) {
-                        Text(
-                            text = "⚠ Pre-release / Beta",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.error
-                        )
+            when (phase) {
+AppUpdatePhase.Downloading -> {
+                    Column(
+                        modifier = Modifier.padding(vertical =  8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        if (progress >=  0f) {
+                            LinearProgressIndicator(
+                                progress = { progress.coerceIn(0f,  1f) },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            Text(
+                                text = stringResource(R.string.shevery_update_download_progress, (progress.coerceIn(0f,  1f) * 100).toInt()),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        } else {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            ) {
+                                LoadingIndicator(modifier = Modifier.size(28.dp))
+                                Text(stringResource(R.string.shevery_update_preparing), style = MaterialTheme.typography.bodyMedium)
+                            }
+                        }
                     }
                 }
-            } else if (result.error != null) {
-                Text(result.error, style = MaterialTheme.typography.bodyMedium)
-            } else {
-                null
+                AppUpdatePhase.Installing -> Row(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+
+                    LoadingIndicator(modifier = Modifier.size(28.dp))
+                    Text(stringResource(R.string.shevery_update_installing), style = MaterialTheme.typography.bodyMedium)
+
+
+                }
+                AppUpdatePhase.Failed -> Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+
+                    Text(errorMessage ?: "?", style = MaterialTheme.typography.bodyMedium)
+
+
+                }
+                AppUpdatePhase.Idle -> {
+                    if (result.hasUpdate && result.latestVersion != null) {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+
+
+                            Text(
+                                text = stringResource(
+                                    R.string.shevery_update_available_msg, 
+                                    result.latestVersion, 
+                                    result.currentVersion
+                                ),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            if (!result.releaseNotes.isNullOrBlank()) {
+                                Text(
+                                    text = result.releaseNotes.take(400).let {
+                                        if (result.releaseNotes.length >400) "$it…" else it
+
+                                    },
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            if (result.isPreRelease) {
+                                Text(
+                                    text = "⚠ Pre-release / Beta",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    } else if (result.error != null) {
+                        Text(result.error ?: "", style = MaterialTheme.typography.bodyMedium)
+                    } else {
+                        null
+
+
+                    }
+                }
             }
         },
         confirmButton = {
-            if (result.hasUpdate && result.downloadUrl != null) {
-                TextButton(onClick = {
-                    CustomTabsHelper.launchUrlOrCopy(context, result.downloadUrl)
-                    onDismiss()
-                }) {
-                    Text(stringResource(R.string.shevery_update_download_apk))
+            when (phase) {
+
+                AppUpdatePhase.Idle -> if (result.hasUpdate && result.downloadUrl != null) {
+                    TextButton(onClick = { startDownload() }) {
+                        Text(stringResource(R.string.shevery_update_download_install))
+                    }
                 }
+                AppUpdatePhase.Failed -> TextButton(onClick = { startDownload() }) {
+                    Text(stringResource(R.string.shevery_update_retry))
+                }
+                else -> Unit
+
+
+
             }
         },
         dismissButton = {
-            if (result.hasUpdate && result.htmlUrl != null) {
-                TextButton(onClick = {
-                    CustomTabsHelper.launchUrlOrCopy(context, result.htmlUrl)
+            when (phase) {
+
+                AppUpdatePhase.Idle -> if (result.hasUpdate && result.htmlUrl != null) {
+                    TextButton(onClick = {
+                        CustomTabsHelper.launchUrlOrCopy(context, result.htmlUrl)
+                        onDismiss()
+                    }) {
+                        Text(stringResource(R.string.shevery_update_view_release))
+                    }
+                } else {
+                    TextButton(onClick = onDismiss) {
+                        Text(stringResource(android.R.string.ok))
+                    }
+                }
+                AppUpdatePhase.Downloading -> TextButton(onClick = onDismiss) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                AppUpdatePhase.Failed -> TextButton(onClick = {
+                    val url = result.downloadUrl ?: result.htmlUrl ?: ""
+                    if (url.isNotBlank()) CustomTabsHelper.launchUrlOrCopy(context, url)
                     onDismiss()
                 }) {
-                    Text(stringResource(R.string.shevery_update_view_release))
+                    Text(stringResource(R.string.shevery_update_download_manual))
                 }
-            } else {
-                TextButton(onClick = onDismiss) {
-                    Text(stringResource(android.R.string.ok))
-                }
+                AppUpdatePhase.Installing -> Unit
+
+
             }
         }
     )

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -417,6 +417,15 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="shevery_update_available_msg">Version %1$s is available (current: %2$s)</string>
     <string name="shevery_update_download_apk">Download APK</string>
     <string name="shevery_update_view_release">View on GitHub</string>
+    <string name="shevery_update_download_install">Download &amp; Install</string>
+    <string name="shevery_update_downloading_title">Downloading update…</string>
+    <string name="shevery_update_download_progress">%1$d%% downloaded</string>
+    <string name="shevery_update_preparing">Preparing download…</string>
+    <string name="shevery_update_installing">Installing update…</string>
+    <string name="shevery_update_install_failed_title">Installation failed</string>
+    <string name="shevery_update_retry">Retry</string>
+    <string name="shevery_update_download_manual">Download manually</string>
+    <string name="shevery_update_install_success">Update installed</string>
     <string name="shevery_update_channel">Update channel</string>
     <string name="shevery_update_channel_summary">Choose update release channel</string>
     <string name="app_update_channel_stable">Stable</string>


### PR DESCRIPTION
Ports MorpheApp's release-download flow into the App-update dialog: the APK now streams in-app with progress and installs through a PackageInstaller session (system confirm(, instead of handing off to the browser.

- New AppUpdateDownloader: OkHttp stream to cache, progress callback, partial-file cleanup.
- New AppUpdateInstaller: PackageInstaller session (originating-uid, self-update ownership, forced user confirm(+, status receiver unregisters itself on first broadcast, TIME-OUT fallback (5min( -> Failed.
 - Dialog state machine: Idle -> Downloading (progress bar( -> Installing -> Failed (Retry / Download-manually in browser(. - SheveryUpdateChecker unchanged: it already locates releases well. - 9 new strings (English only — translations via PRs as usual(.\n\nManual test flow: About -> Check for updates -> Download & Install -> progress -> system confirm dialog -> package replaced;home card clears once next check runs (PR #182 write-through(.