### PR TITLE
Route home update card through shared install flow

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -99,6 +99,8 @@ import moe.shizuku.manager.adb.AdbStarter
 import moe.shizuku.manager.app.AppActivity
 import moe.shizuku.manager.management.ApplicationManagementActivity
 import moe.shizuku.manager.module.AdbModuleManager
+import moe.shizuku.manager.module.update.SheveryAppUpdateDialog
+import moe.shizuku.manager.module.update.SheveryAppUpdateResult
 
 import moe.shizuku.manager.management.appsViewModel
 import moe.shizuku.manager.model.ServiceStatus
@@ -1064,16 +1066,31 @@ private fun HomeScreen(
                 }
                 val version = pendingVersion.value
                 val url = pendingUrl.value
+                val showAppUpdateInstall = remember { mutableStateOf(false) }
                 if (!version.isNullOrEmpty() && !url.isNullOrEmpty()) {
+                    if (showAppUpdateInstall.value) {
+                        SheveryAppUpdateDialog(
+                            result = SheveryAppUpdateResult(
+                                hasUpdate = true,
+                                currentVersion = BuildConfig.VERSION_NAME,
+                                latestVersion = version,
+                                releaseTitle = null,
+                                releaseNotes = null,
+                                downloadUrl = url,
+                                htmlUrl = null,
+                                isPreRelease = false,
+                                publishedAt = null,
+                                error = null
+                            ),
+                            onDismiss = { showAppUpdateInstall.value = false },
+                        )
+                    }
                     HomeCard(
                         icon = R.drawable.ic_outline_info_24,
                         title = ctx.getString(R.string.home_update_available_title, version),
                         body = ctx.getString(R.string.home_update_available_body),
                         enabled = true,
-                        onClick = {
-                            val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
-                            ctx.startActivity(intent)
-                        }
+                        onClick = { showAppUpdateInstall.value = true },
                     )
                 }
             }

--- a/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
@@ -69,10 +69,27 @@ fun AppUpdateSettingsGroup() {
     }
     val version = pendingVersion.value
     val url = pendingUrl.value
+    val showPendingInstall = remember { mutableStateOf(false) }
     if (!version.isNullOrEmpty() && !url.isNullOrEmpty()) {
-        val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
+        if (showPendingInstall.value) {
+            SheveryAppUpdateDialog(
+                result = SheveryAppUpdateResult(
+                    hasUpdate = true,
+                    currentVersion = BuildConfig.VERSION_NAME,
+                    latestVersion = version,
+                    releaseTitle = null,
+                    releaseNotes = null,
+                    downloadUrl = url,
+                    htmlUrl = null,
+                    isPreRelease = false,
+                    publishedAt = null,
+                    error = null
+                ),
+                onDismiss = { showPendingInstall.value = false },
+            )
+        }
         Surface(
-            onClick = { context.startActivity(intent) },
+            onClick = { showPendingInstall.value = true },
             shape = MaterialTheme.shapes.extraLarge,
             color = MaterialTheme.colorScheme.primaryContainer,
             tonalElevation = 2.dp,

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -436,7 +436,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="shevery_update_modules_group_title">Module Updates &amp; Catalog</string>
     <string name="shevery_update_check_failed">Update check failed: %s</string>
     <string name="home_update_available_title">Shevery update available: %s</string>
-    <string name="home_update_available_body">A newer version is ready. Tap to download.</string>
+    <string name="home_update_available_body">A newer version is ready. Tap to update.</string>
 
     <!-- Module Catalog -->
     <string name="modules_catalog">Catalog</string>


### PR DESCRIPTION
Both update entry points (Settings banner + Home card( now open the shared `SheveryAppUpdateDialog` install flow from #183 (streamed in-app APK download → PackageInstaller, browser handoff kept as manual fallback( instead of firing an ACTION_VIEW browser intent.\n\n- Home: tap now shows the dialog (progress → install → system confirm(.\n- Settings banner: same dialog as the check-button path.\n- String: `home_update_available_body` → "Tap to update." (was "download"(.\n\nBuilds run on GitHub Actions only (no local Gradle(.