### PR TITLE
fix(watchdog): keyguard-safe unified restart under single ErrorProtect toggle

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -128,6 +128,7 @@ import rikka.lifecycle.viewModels
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuApiConstants
 import moe.shizuku.manager.module.ModuleSettings
+import moe.shizuku.manager.module.update.SheveryUpdateChecker
 import moe.shizuku.manager.compat.StubManager
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import androidx.lifecycle.lifecycleScope
@@ -1059,12 +1060,22 @@ private fun HomeScreen(
                 val pendingUrl = remember { mutableStateOf<String?>(null) }
                 val ctx = LocalContext.current
                 LaunchedEffect(Unit) {
-                    pendingVersion.value = ModuleSettings.getPendingUpdateVersion()
-                    pendingUrl.value = ModuleSettings.getPendingUpdateUrl()
+                    val storedVersion = ModuleSettings.getPendingUpdateVersion()
+                    val storedUrl = ModuleSettings.getPendingUpdateUrl()
+                    if (!storedVersion.isNullOrEmpty() && !storedUrl.isNullOrEmpty()
+                        && !SheveryUpdateChecker.isTagNewerThanInstalled(storedVersion)
+                    ) {
+                        ModuleSettings.clearPendingUpdate()
+                    } else {
+                        pendingVersion.value = storedVersion
+                        pendingUrl.value = storedUrl
+                    }
                 }
                 val version = pendingVersion.value
                 val url = pendingUrl.value
-                if (!version.isNullOrEmpty() && !url.isNullOrEmpty()) {
+                if (!version.isNullOrEmpty() && !url.isNullOrEmpty()
+                    && SheveryUpdateChecker.isTagNewerThanInstalled(version)
+                ) {
                     HomeCard(
                         icon = R.drawable.ic_outline_info_24,
                         title = ctx.getString(R.string.home_update_available_title, version),

--- a/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
@@ -244,16 +244,16 @@ object ModuleSettings {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_NOTIFY_DEATH, value).apply()
     }
 
-    fun isErrorProtectEnabled(): Boolean {
+    fun isWatchdogEnabled(): Boolean {
         return ShizukuSettings.getPreferences().getBoolean(KEY_ERROR_PROTECT, true)
     }
 
-    fun setErrorProtectEnabled(value: Boolean) {
+    fun setWatchdogEnabled(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_ERROR_PROTECT, value).apply()
     }
 
     // Maps pre-consolidation watchdog prefs (PR #186（ into the single master toggle.
-    // Users who had the legacy keep-alive or auto-restart prefs enabled but ErrorProtect
+    // Users who had the legacy keep-alive or auto-restart prefs enabled but Watchdog
     // off would otherwise silently lose watchdog coverage after updating.
 
     fun migrateLegacyWatchdogPrefs() {

--- a/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
@@ -29,11 +29,12 @@ object ModuleSettings {
     private const val KEY_TRUSTED_MODULES = "adb_modules_trusted_modules"
     private const val KEY_CONNECTOR_ENABLED = "shizuku_connector_enabled"
     private const val KEY_DHIZUKU_ENABLED = "shizuku_dhizuku_enabled"
-    private const val KEY_KEEP_ALIVE = "shizuku_keep_alive"
     private const val KEY_VERBOSE_LOGGING = "shizuku_verbose_logging"
-    private const val KEY_AUTO_RESTART = "shizuku_auto_restart_on_crash"
     private const val KEY_NOTIFY_DEATH = "shizuku_notify_service_death"
     private const val KEY_ERROR_PROTECT = "shizuku_error_protect"
+    // Legacy watchdog prefs from before the toggle consolidation (PR #186).
+    private const val KEY_LEGACY_KEEP_ALIVE = "shizuku_keep_alive"
+    private const val KEY_LEGACY_AUTO_RESTART = "shizuku_auto_restart_on_crash"
     private const val KEY_COMPAT_STUB = "shizuku_compat_stub"
 
 
@@ -227,28 +228,12 @@ object ModuleSettings {
     }
 
 
-    fun isKeepAlive(): Boolean {
-        return ShizukuSettings.getPreferences().getBoolean(KEY_KEEP_ALIVE, false)
-    }
-
-    fun setKeepAlive(value: Boolean) {
-        ShizukuSettings.getPreferences().edit().putBoolean(KEY_KEEP_ALIVE, value).apply()
-    }
-
     fun isVerboseLogging(): Boolean {
         return ShizukuSettings.getPreferences().getBoolean(KEY_VERBOSE_LOGGING, false)
     }
 
     fun setVerboseLogging(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_VERBOSE_LOGGING, value).apply()
-    }
-
-    fun isAutoRestartOnCrash(): Boolean {
-        return ShizukuSettings.getPreferences().getBoolean(KEY_AUTO_RESTART, false)
-    }
-
-    fun setAutoRestartOnCrash(value: Boolean) {
-        ShizukuSettings.getPreferences().edit().putBoolean(KEY_AUTO_RESTART, value).apply()
     }
 
     fun isNotifyOnServiceDeath(): Boolean {
@@ -265,6 +250,20 @@ object ModuleSettings {
 
     fun setErrorProtectEnabled(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_ERROR_PROTECT, value).apply()
+    }
+
+    // Maps pre-consolidation watchdog prefs (PR #186（ into the single master toggle.
+    // Users who had the legacy keep-alive or auto-restart prefs enabled but ErrorProtect
+    // off would otherwise silently lose watchdog coverage after updating.
+
+    fun migrateLegacyWatchdogPrefs() {
+        val prefs = ShizukuSettings.getPreferences()
+        if (prefs.getBoolean(KEY_ERROR_PROTECT, true)) return
+        val legacyEnabled = prefs.getBoolean(KEY_LEGACY_KEEP_ALIVE, false) ||
+            prefs.getBoolean(KEY_LEGACY_AUTO_RESTART, false)
+        if (legacyEnabled) {
+            prefs.edit().putBoolean(KEY_ERROR_PROTECT, true).apply()
+        }
     }
 
     fun isCompatibilityStubEnabled(): Boolean {

--- a/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
@@ -64,12 +64,24 @@ fun AppUpdateSettingsGroup() {
     val pendingVersion = remember { mutableStateOf<String?>(null) }
     val pendingUrl = remember { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) {
-        pendingVersion.value = ModuleSettings.getPendingUpdateVersion()
-        pendingUrl.value = ModuleSettings.getPendingUpdateUrl()
+        val storedVersion = ModuleSettings.getPendingUpdateVersion()
+        val storedUrl = ModuleSettings.getPendingUpdateUrl()
+        if (!storedVersion.isNullOrEmpty() && !storedUrl.isNullOrEmpty()
+            && !SheveryUpdateChecker.isTagNewerThanInstalled(storedVersion)
+        ) {
+            // Stale pending (e.g. r35 stored before r36 was installed, with no
+            // check run since): drop it instead of advertising an old version.
+            ModuleSettings.clearPendingUpdate()
+        } else {
+            pendingVersion.value = storedVersion
+            pendingUrl.value = storedUrl
+        }
     }
     val version = pendingVersion.value
     val url = pendingUrl.value
-    if (!version.isNullOrEmpty() && !url.isNullOrEmpty()) {
+    if (!version.isNullOrEmpty() && !url.isNullOrEmpty()
+        && SheveryUpdateChecker.isTagNewerThanInstalled(version)
+    ) {
         val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
         Surface(
             onClick = { context.startActivity(intent) },

--- a/manager/src/main/java/moe/shizuku/manager/module/update/SheveryUpdateChecker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/SheveryUpdateChecker.kt
@@ -196,5 +196,19 @@ class SheveryUpdateChecker private constructor() {
                 }
             }
         }
+
+        /**
+         * True when [releaseTag] (e.g. "r35") is newer than the installed build.
+         * Used to suppress stale stored pendings: a banner saved before an update
+         * must not keep advertising the old version after a newer build is installed.
+         */
+        fun isTagNewerThanInstalled(releaseTag: String?): Boolean {
+            if (releaseTag.isNullOrBlank()) return false
+            return getInstance().isReleaseNewer(
+                releaseTag,
+                BuildConfig.VERSION_NAME,
+                BuildConfig.VERSION_CODE
+            )
+        }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -9,8 +9,6 @@ import android.os.Build
 import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import com.topjohnwu.superuser.Shell
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,21 +18,14 @@ import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
-import moe.shizuku.manager.adb.AdbClient
-import moe.shizuku.manager.adb.AdbStarter
-import moe.shizuku.manager.adb.AdbKey
-import moe.shizuku.manager.adb.AdbMdns
-import moe.shizuku.manager.adb.PreferenceAdbKeyStore
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.ktx.logi
 import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.server.IShizukuService
 import moe.shizuku.manager.starter.Starter
-import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.ShizukuStateMachine
+import moe.shizuku.manager.worker.AdbStartWorker
 import rikka.shizuku.Shizuku
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 object WatchdogManager {
@@ -47,9 +38,9 @@ object WatchdogManager {
     )
 
     private const val CHANNEL_ID = "service_watchdog"
+    private const val DEATH_CHANNEL_ID = "service_watchdog_death"
     private const val NOTIFICATION_ID = 1001
     private const val EXPECTED_DEATH_WINDOW_MS = 10_000L
-    private const val WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS = 5L
     private const val DHIZUKU_BIND_TIMEOUT_MS = 10_000L
     private const val KEY_USER_STOP_REQUESTED = "watchdog_user_stop_requested"
 
@@ -80,6 +71,9 @@ object WatchdogManager {
 
     fun init(context: Context) {
         val appContext = context.applicationContext
+        // One-time migration for the watchdog toggle consolidation: run before the
+        // guarded section so it applies even when the service never starts.
+        ModuleSettings.migrateLegacyWatchdogPrefs()
         if (initialized) return
         initialized = true
 
@@ -97,7 +91,18 @@ object WatchdogManager {
     }
 
     fun isEnabled(): Boolean {
-        return ModuleSettings.isAutoRestartOnCrash() || ModuleSettings.isKeepAlive() || ModuleSettings.isErrorProtectEnabled()
+        return ModuleSettings.isErrorProtectEnabled()
+    }
+
+    /**
+     * True while the expected-death suppression window (10s( is still open. A stale
+     *  flag must not block the watchdog poll loop forever when no binder transition fires.
+     */
+    fun isExpectingDeathActive(): Boolean {
+        if (!expectingDeath) return false
+        val deadline = expectedDeathDeadlineMillis
+        if (deadline == 0L) return true
+        return SystemClock.elapsedRealtime() <= deadline
     }
 
     fun shouldRunService(): Boolean {
@@ -164,8 +169,8 @@ object WatchdogManager {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                CHANNEL_ID,
-                context.getString(R.string.notification_channel_watchdog),
+                DEATH_CHANNEL_ID,
+                context.getString(R.string.notification_channel_watchdog_death),
                 NotificationManager.IMPORTANCE_DEFAULT
             )
             notificationManager.createNotificationChannel(channel)
@@ -177,7 +182,7 @@ object WatchdogManager {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(context, DEATH_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_server_error_24dp)
             .setContentTitle(context.getString(R.string.notification_watchdog_title))
             .setContentText(context.getString(R.string.notification_watchdog_text))
@@ -332,80 +337,12 @@ object WatchdogManager {
         }
     }
 
-    private suspend fun restartAdb(context: Context) {
-        if (ShizukuSettings.isTcpMode() && restartTcp(context)) {
-            return
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            restartWirelessAdb(context)
-        }
-    }
+    private fun restartAdb(context: Context) {
+        // Route restarts through the keyguard-aware worker: it waits for
+        // USER_PRESENT before starting,and re-runs full discovery + adbd rebind,
+        // instead of directly re-kicking a doomed transport behind the lockscreen.
 
-    private suspend fun restartTcp(context: Context): Boolean {
-        val livePort = EnvironmentUtils.getLiveAdbTcpPort()
-        val configuredPort = EnvironmentUtils.getAdbTcpPort()
-        val candidatePorts = sequenceOf(livePort, configuredPort, 5555)
-            .filter { it > 0 }
-            .distinct()
-            .toList()
-
-        if (candidatePorts.isEmpty()) {
-            logd("Restart via TCP skipped: no candidate ADB TCP ports")
-            return false
-        }
-
-        val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
-        for (port in candidatePorts) {
-            try {
-                AdbClient("127.0.0.1", port, key).use { client ->
-                    client.connect()
-                    client.shellCommand(Starter.internalCommand) { _ -> }
-                }
-                if (waitForShizukuBinder()) {
-                    logi("Restart via TCP verified on port $port")
-                    return true
-                }
-                logd("Restart via TCP command completed on port $port, but binder did not become available")
-            } catch (e: Exception) {
-                logd("Restart via TCP failed on port $port: ${e.message}")
-            }
-        }
-        return false
-    }
-
-    private suspend fun restartWirelessAdb(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return false
-
-        val appContext = context.applicationContext
-        val startAttempted = AtomicBoolean(false)
-        val result = CompletableDeferred<Boolean>()
-        val adbMdns = AdbMdns(appContext, AdbMdns.TLS_CONNECT) { port ->
-            if (port <= 0 || result.isCompleted || !startAttempted.compareAndSet(false, true)) return@AdbMdns
-            CoroutineScope(Dispatchers.IO).launch {
-                try {
-                    AdbStarter.start(port = port, context = appContext, listener = { _ -> })
-                    if (waitForShizukuBinder()) {
-                        logi("Restart via Wireless ADB successful from discovered port $port")
-                        result.complete(true)
-                    } else {
-                        logd("Restart via Wireless ADB command completed on port $port, but binder did not become available")
-                        startAttempted.set(false)
-                    }
-                } catch (e: Exception) {
-                    logd("Restart via Wireless ADB failed on port $port: ${e.message}")
-                    startAttempted.set(false)
-                }
-            }
-        }
-
-        return try {
-            adbMdns.start()
-            withTimeoutOrNull(WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS * 1000L + 20_000L) {
-                result.await()
-            } ?: false
-        } finally {
-            adbMdns.stop()
-        }
+        AdbStartWorker.enqueueIfIdle(context.applicationContext)
     }
 
     private suspend fun waitForShizukuBinder(timeoutMs: Long = 10_000L): Boolean {

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -91,7 +91,7 @@ object WatchdogManager {
     }
 
     fun isEnabled(): Boolean {
-        return ModuleSettings.isErrorProtectEnabled()
+        return ModuleSettings.isWatchdogEnabled()
     }
 
     /**
@@ -131,7 +131,7 @@ object WatchdogManager {
             return
         }
 
-        if (ModuleSettings.isNotifyOnServiceDeath()) {
+        if (ModuleSettings.isNotifyOnServiceDeath() || isEnabled()) {
             showDeathNotification(context)
         }
 
@@ -392,7 +392,7 @@ object WatchdogManager {
                     logi("Watchdog verified Shevery binder after Dhizuku restart")
                 } else {
                     logd("Watchdog Dhizuku starter command completed, but binder did not become available")
-                    if (ModuleSettings.isNotifyOnServiceDeath()) {
+                    if (ModuleSettings.isNotifyOnServiceDeath() || isEnabled()) {
                         showDeathNotification(context)
                     }
                 }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -1,5 +1,6 @@
 package moe.shizuku.manager.service
 
+import android.app.KeyguardManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -20,6 +21,13 @@ class WatchdogService : Service() {
 
     private var errorProtectJob: Job? = null
     private val errorProtectScope = CoroutineScope(Dispatchers.Default)
+
+    // ErrorProtect restart backoff: doubles per failure, from 30s up to a 5min cap.
+
+    // The 10s base poll stays for health checks; only RESTART actions back off, so the loop cannot
+    // hammer adbd behind the lockscreen or in a permanently-dead state.
+    private val retryBackoffBaseMs = 30_000L
+    private val retryBackoffMaxMs = 300_000L
 
     private val binderReceivedListener = object : rikka.shizuku.Shizuku.OnBinderReceivedListener {
         override fun onBinderReceived() {
@@ -45,6 +53,8 @@ class WatchdogService : Service() {
 
         startAsForeground()
         startErrorProtectLoop()
+        rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
+        rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
         rikka.shizuku.Shizuku.addBinderReceivedListenerSticky(binderReceivedListener)
         rikka.shizuku.Shizuku.addBinderDeadListener(binderDeadListener)
         return START_STICKY
@@ -62,6 +72,7 @@ class WatchdogService : Service() {
         if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) return
 
         errorProtectJob = errorProtectScope.launch {
+            var consecutiveFailures = 0
             while (isActive) {
                 delay(10_000)
                 if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) break
@@ -78,12 +89,30 @@ class WatchdogService : Service() {
                     logd("ErrorProtect: Binder check threw exception: ${e.message}")
                 }
 
-                if (!healthy && !WatchdogManager.expectingDeath && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
-                    logd("ErrorProtect: Service check failed. Stopping and restarting...")
+                if (!healthy && !WatchdogManager.isExpectingDeathActive() && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
+
+                    // While the keyguard is up, Android tears down plain-TCP adb and kills
+                    // the server. Restarting behind the lockscreen just re-kicks the same doomed
+                    // transport every 10s (old behavior), which wedges 25-45s. Defer until unlock.
+                    // the keyguard-aware AdbStartWorker waits for USER_PRESENT and re-runs full
+                    // discovery + adbd rebind itself.
+                    val km = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+                    if (km?.isKeyguardLocked == true) {
+                        logd("ErrorProtect: device locked -- deferring restart until unlock")
+                        continue
+                    }
+                    logd("ErrorProtect: service check failed. Stopping and restarting...")
                     withContext(Dispatchers.IO) {
                         moe.shizuku.manager.service.WatchdogManager.stopServer(applicationContext, userInitiated = false)
                         moe.shizuku.manager.service.WatchdogManager.attemptRestart(applicationContext)
                     }
+                    consecutiveFailures += 1
+                    val shiftCount = (consecutiveFailures.minus(1)).coerceAtMost(4)
+                    val backoffMs = (retryBackoffBaseMs * (1L shl shiftCount)).coerceAtMost(retryBackoffMaxMs)
+                    logd("ErrorProtect: restart scheduled; backing off ${backoffMs} ms before next check")
+                    delay(backoffMs)
+                } else if (healthy) {
+                    consecutiveFailures = 0
                 }
             }
         }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -19,10 +19,10 @@ import moe.shizuku.manager.ktx.logd
 
 class WatchdogService : Service() {
 
-    private var errorProtectJob: Job? = null
-    private val errorProtectScope = CoroutineScope(Dispatchers.Default)
+    private var watchdogJob: Job? = null
+    private val watchdogScope = CoroutineScope(Dispatchers.Default)
 
-    // ErrorProtect restart backoff: doubles per failure, from 30s up to a 5min cap.
+    // Watchdog restart backoff: doubles per failure, from 30s up to a 5min cap.
 
     // The 10s base poll stays for health checks; only RESTART actions back off, so the loop cannot
     // hammer adbd behind the lockscreen or in a permanently-dead state.
@@ -52,7 +52,7 @@ class WatchdogService : Service() {
         }
 
         startAsForeground()
-        startErrorProtectLoop()
+        startWatchdogLoop()
         rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
         rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
         rikka.shizuku.Shizuku.addBinderReceivedListenerSticky(binderReceivedListener)
@@ -63,19 +63,19 @@ class WatchdogService : Service() {
     override fun onDestroy() {
         rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
         rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
-        stopErrorProtectLoop()
+        stopWatchdogLoop()
         super.onDestroy()
     }
 
-    private fun startErrorProtectLoop() {
-        errorProtectJob?.cancel()
-        if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) return
+    private fun startWatchdogLoop() {
+        watchdogJob?.cancel()
+        if (!moe.shizuku.manager.module.ModuleSettings.isWatchdogEnabled()) return
 
-        errorProtectJob = errorProtectScope.launch {
+        watchdogJob = watchdogScope.launch {
             var consecutiveFailures = 0
             while (isActive) {
                 delay(10_000)
-                if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) break
+                if (!moe.shizuku.manager.module.ModuleSettings.isWatchdogEnabled()) break
 
                 var healthy = false
                 try {
@@ -86,7 +86,7 @@ class WatchdogService : Service() {
                         }
                     }
                 } catch (e: Throwable) {
-                    logd("ErrorProtect: Binder check threw exception: ${e.message}")
+                    logd("Watchdog: Binder check threw exception: ${e.message}")
                 }
 
                 if (!healthy && !WatchdogManager.isExpectingDeathActive() && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
@@ -98,10 +98,10 @@ class WatchdogService : Service() {
                     // discovery + adbd rebind itself.
                     val km = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
                     if (km?.isKeyguardLocked == true) {
-                        logd("ErrorProtect: device locked -- deferring restart until unlock")
+                        logd("Watchdog: device locked -- deferring restart until unlock")
                         continue
                     }
-                    logd("ErrorProtect: service check failed. Stopping and restarting...")
+                    logd("Watchdog: service check failed. Stopping and restarting...")
                     withContext(Dispatchers.IO) {
                         moe.shizuku.manager.service.WatchdogManager.stopServer(applicationContext, userInitiated = false)
                         moe.shizuku.manager.service.WatchdogManager.attemptRestart(applicationContext)
@@ -109,7 +109,7 @@ class WatchdogService : Service() {
                     consecutiveFailures += 1
                     val shiftCount = (consecutiveFailures.minus(1)).coerceAtMost(4)
                     val backoffMs = (retryBackoffBaseMs * (1L shl shiftCount)).coerceAtMost(retryBackoffMaxMs)
-                    logd("ErrorProtect: restart scheduled; backing off ${backoffMs} ms before next check")
+                    logd("Watchdog: restart scheduled; backing off ${backoffMs} ms before next check")
                     delay(backoffMs)
                 } else if (healthy) {
                     consecutiveFailures = 0
@@ -118,9 +118,9 @@ class WatchdogService : Service() {
         }
     }
 
-    private fun stopErrorProtectLoop() {
-        errorProtectJob?.cancel()
-        errorProtectJob = null
+    private fun stopWatchdogLoop() {
+        watchdogJob?.cancel()
+        watchdogJob = null
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
@@ -29,9 +29,7 @@ class LabFeaturesActivity : AppActivity() {
         setContent {
             var connectorEnabled by remember { mutableStateOf(ModuleSettings.isConnectorEnabled()) }
             var dhizukuEnabled by remember { mutableStateOf(ModuleSettings.isDhizukuEnabled()) }
-            var keepAlive by remember { mutableStateOf(ModuleSettings.isKeepAlive()) }
             var verboseLogging by remember { mutableStateOf(ModuleSettings.isVerboseLogging()) }
-            var autoRestart by remember { mutableStateOf(ModuleSettings.isAutoRestartOnCrash()) }
             var notifyDeath by remember { mutableStateOf(ModuleSettings.isNotifyOnServiceDeath()) }
             var showUnsafeDialog by remember { mutableStateOf(false) }
             var showDhizukuDialog by remember { mutableStateOf(false) }
@@ -77,30 +75,6 @@ class LabFeaturesActivity : AppActivity() {
 
                     item {
                         SettingsGroup(title = stringResource(R.string.lab_service_behavior_title)) {
-                            SwitchSettingsRow(
-                                icon = R.drawable.ic_server_ok_24dp,
-                                title = stringResource(R.string.lab_keep_alive_title),
-                                summary = stringResource(R.string.lab_keep_alive_summary),
-                                checked = keepAlive,
-                                onCheckedChange = { value ->
-                                    keepAlive = value
-                                    ModuleSettings.setKeepAlive(value)
-                                    WatchdogManager.reconcileService(this@LabFeaturesActivity)
-                                }
-                            )
-                            GroupDivider()
-                            SwitchSettingsRow(
-                                icon = R.drawable.ic_system_icon,
-                                title = stringResource(R.string.lab_auto_restart_title),
-                                summary = stringResource(R.string.lab_auto_restart_summary),
-                                checked = autoRestart,
-                                onCheckedChange = { value ->
-                                    autoRestart = value
-                                    ModuleSettings.setAutoRestartOnCrash(value)
-                                    WatchdogManager.reconcileService(this@LabFeaturesActivity)
-                                }
-                            )
-                            GroupDivider()
                             SwitchSettingsRow(
                                 icon = R.drawable.ic_outline_notifications_active_24,
                                 title = stringResource(R.string.lab_notify_death_title),

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -140,8 +140,8 @@ fun SettingsScreen() {
     var adbStartOnBoot by remember {
         mutableStateOf(ShizukuSettings.getStartOnBootAdb())
     }
-    var errorProtect by remember {
-        mutableStateOf(ModuleSettings.isErrorProtectEnabled())
+    var watchdog by remember {
+        mutableStateOf(ModuleSettings.isWatchdogEnabled())
     }
     var compatStub by remember {
         mutableStateOf(StubManager.isInstalled(context))
@@ -263,7 +263,7 @@ fun SettingsScreen() {
                 Toast.makeText(context, "Restore completed successfully", Toast.LENGTH_SHORT).show()
                 startOnBoot = ShizukuSettings.getStartOnBoot()
                 adbStartOnBoot = ShizukuSettings.getStartOnBootAdb()
-                errorProtect = ModuleSettings.isErrorProtectEnabled()
+                watchdog = ModuleSettings.isWatchdogEnabled()
                 languageTag = prefs.getString(LANGUAGE, "SYSTEM") ?: "SYSTEM"
                 nightMode = ShizukuSettings.getNightMode()
                 blackNightTheme = ThemeHelper.isBlackNightTheme(context)
@@ -412,10 +412,10 @@ fun SettingsScreen() {
                     icon = R.drawable.ic_server_restart,
                     title = stringResource(R.string.error_protect_title),
                     summary = stringResource(R.string.error_protect_summary),
-                    checked = errorProtect,
+                    checked = watchdog,
                     onCheckedChange = { enabled ->
-                        ModuleSettings.setErrorProtectEnabled(enabled)
-                        errorProtect = ModuleSettings.isErrorProtectEnabled()
+                        ModuleSettings.setWatchdogEnabled(enabled)
+                        watchdog = ModuleSettings.isWatchdogEnabled()
                         moe.shizuku.manager.service.WatchdogManager.reconcileService(context)
                     }
                 )

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -114,6 +114,28 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             }
     }
 
+    /**
+     * Expedited work on API <31 runs inside a foreground service, and WorkManager
+     * fetches its notification through this method BEFORE doWork() runs. The default
+     * implementation throws IllegalStateException, which crashed every
+     * watchdog-triggered ADB restart on Android 7-11. Reuses the starter channel
+     * and NOTIFICATION_ID so the worker's own progress updates replace it.
+     * WorkManager only calls this on API <31 (it skips the foreground path on
+     * 31+), so the typeless form is used: no FGS-type bits that those releases
+     * don't know. Manifest's SystemForegroundService declaration is unaffected.
+     */
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        ShizukuReceiverStarter.ensureChannel(applicationContext)
+        val notification = NotificationCompat.Builder(applicationContext, ShizukuReceiverStarter.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_system_icon)
+            .setContentTitle(applicationContext.getString(R.string.wadb_notification_title))
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+        @Suppress("DEPRECATION")
+        return ForegroundInfo(ShizukuReceiverStarter.NOTIFICATION_ID, notification)
+    }
+
     override suspend fun doWork(): Result {
         try {
             ShizukuReceiverStarter.updateNotification(

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -24,7 +24,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.adb.AdbMdns
@@ -63,7 +65,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             val request = OneTimeWorkRequestBuilder<AdbStartWorker>()
                 .setConstraints(constraints)
-                .setBackoffCriteria(BackoffPolicy.LINEAR, 30_000L, TimeUnit.MILLISECONDS)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30_000L, TimeUnit.MILLISECONDS)
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
 
@@ -119,7 +121,50 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 ShizukuReceiverStarter.WorkerState.RUNNING
             )
 
-            // No FGS promotion here: the reference (thedjchi/Shizuku( only foregrounds
+            // Gate ALL start paths (TCP fast-path, TV, mDNS) behind unlock.
+            // Android tears down plain-TCP adb while the keyguard is up, so starting
+            // behind the lockscreen (as the watchdog did) just loops. Waitfor
+            // USER_PRESENT like the reference implementation, bounded so a locked
+            // device falls through to backoff retries instead of wedging the worker.
+            val keyguardManager = applicationContext.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+            if (keyguardManager?.isKeyguardLocked == true) {
+                Log.d(AppConstants.TAG, "AdbStartWorker: device locked -- waiting for USER_PRESENT before starting ADB")
+                val unlocked = withTimeoutOrNull(30_000L) {
+                    suspendCancellableCoroutine<Boolean> { cont ->
+                        val filter = IntentFilter(Intent.ACTION_USER_PRESENT)
+                        val unlockReceiver = object : BroadcastReceiver() {
+                            override fun onReceive(context: Context, intent: Intent) {
+                                if (intent.action == Intent.ACTION_USER_PRESENT) {
+                                    runCatching { applicationContext.unregisterReceiver(this) }
+                                    if (cont.isActive) cont.resumeWith(kotlin.Result.success(true))
+                                }
+                            }
+                        }
+                        val receiverFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            ContextCompat.RECEIVER_EXPORTED
+                        } else {
+                            ContextCompat.RECEIVER_NOT_EXPORTED
+                        }
+                        ContextCompat.registerReceiver(applicationContext, unlockReceiver, filter, receiverFlags)
+                        // Re-check after registration: the device may have unlocked between
+                        // the check above and now, so USER_PRESENT fired and was missed.
+
+                        if (keyguardManager?.isKeyguardLocked == false) {
+                            runCatching { applicationContext.unregisterReceiver(unlockReceiver) }
+                            if (cont.isActive) cont.resumeWith(kotlin.Result.success(true))
+                        }
+                        cont.invokeOnCancellation {
+                            runCatching { applicationContext.unregisterReceiver(unlockReceiver) }
+                        }
+                    }
+                }
+                if (unlocked != true) {
+                    Log.d(AppConstants.TAG, "AdbStartWorker: device stayed locked; parking worker for backoff retry")
+                    return Result.retry()
+                }
+            }
+
+            // No FGS promotion here:the reference (thedjchi/Shizuku( only foregrounds
             // to wait out an *unbounded* keyguard unlock; every wait in our fork is
             // bounded (15s discovery, 30s unlock(+ plus retries, so a background
             // startForegroundService would only throw ForegroundServiceStartNotAllowed
@@ -142,12 +187,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             }
 
             val tcpPort = EnvironmentUtils.getAdbTcpPort()
+            val liveTcpPort = EnvironmentUtils.getLiveAdbTcpPort()
 
             val port = if (EnvironmentUtils.isTelevision()) {
                 // TV devices with a configured/static TCP port use TCP directly;
                 // avoid mDNS discovery which is unreliable on LEANBACK.
                 if (tcpPort > 0) tcpPort else throw SecurityException("TV device requires TCP ADB port to be configured")
-            } else if (!EnvironmentUtils.isWifiRequired() && EnvironmentUtils.isAdbPortLive(tcpPort)) {
+            } else if (!EnvironmentUtils.isWifiRequired() && liveTcpPort > 0) {
 
                 // A configured/static TCP port that is actually live can be used directly.
 
@@ -156,14 +202,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // AFTER the first successful start rebinds adbd to it. When a configured port
                 // is stale (e.g., fresh reboot before the service started(, fall through to mDNS
                 // so the worker still discovers the live random wireless port.
-                tcpPort
+                liveTcpPort
             } else {
                 // mDNS advert can go stale when Wi-Fi drops and reconnects (the
                 // Framework never re-publishes _adb-tls-connect(; adbd's TLS
                 // listener usually survives on loopback though,cached last port probe
                 // finds it instantly,and a wrong-service connect dies fast (
                 // TLS/A_AUTH handshake(, so this fallback is safe.
-                val liveTcpPort = EnvironmentUtils.getLiveAdbTcpPort()
                 if (liveTcpPort >   0) liveTcpPort else callbackFlow {
                     val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->
                         if (p > 0) trySend(p)

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -337,7 +337,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="lab_auto_restart_title">Auto-Restart on Crash</string>
     <string name="lab_auto_restart_summary">Automatically attempt to restart the Shevery service if it crashes unexpectedly</string>
     <string name="lab_notify_death_title">Notify on Service Stop</string>
-    <string name="lab_notify_death_summary">Show a notification when the Shevery service stops unexpectedly</string>
+    <string name="lab_notify_death_summary">Show a notification when the Shevery service stops unexpectedly (always shown while Watchdog is on).</string>
 
     <!-- Lab Features - Debugging -->
     <string name="lab_debugging_title">Debugging</string>
@@ -599,7 +599,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="diagnostics_unknown">unknown</string>
 
     <!-- ErrorProtect &amp; TCP 5555 -->
-    <string name="error_protect_title">ErrorProtect</string>
+    <string name="error_protect_title">Watchdog</string>
     <string name="error_protect_summary">Check process health and transactional errors every 10 seconds. Automatically stops and restarts Shevery if issues are found.</string>
     <string name="settings_tcp_5555_title">TCP Binding 5555</string>
     <string name="settings_tcp_5555_summary">Bind local ADB server to port 5555 to keep it working without Wireless Debugging port updates.</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -344,6 +344,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="lab_verbose_logging_title">Verbose Logging</string>
     <string name="lab_verbose_logging_summary">Write detailed debug logs to Logcat. Disable in production to save battery</string>
     <string name="notification_channel_watchdog">Service Watchdog</string>
+    <string name="notification_channel_watchdog_death">Watchdog alert</string>
     <string name="notification_watchdog_title">Shevery Service Stopped</string>
     <string name="notification_watchdog_text">The Shevery service has stopped unexpectedly.</string>
     <string name="watchdog_service_title">Shevery watchdog is active</string>


### PR DESCRIPTION
Consolidates the two watchdog switches into one **ErrorProtect** toggle and makes every watchdog restart lock-screen-safe.

## What changed

- **Single toggle** ErrorsProtect now drives **both** watchdogs:
  - the 10s binder health poll（ WatchdogService
  -the DJ CHI-ported binder-death restart（ now gated by `isErrorProtectEnabled()` in `WatchdogManager`
- **Lab Features de-duplicated**:removed the duplicate `Keep Service Alive`/`Auto Restart on Crash` switches; only `Notify on Service Death` remains there
- **Lock-screen fix**:every restart now routes through the keyguard-aware `AdbStartWorker`（ which waits for `USER_PRESENT` instead of directly re-kicking a doomed TCP transport behind the lockscreen
- **Exponential backoff**:restart attempts back off 30s → 5min between health checks,so the loop cannot hammer adbd behind the lockscreen or in a permanently-dead state

## Behavior contract

- `ErrorProtect ON` = 10s polling + binder-death restart
- `ErrorProtect OFF` = no watchdog（ both off）

## Notes

- No local Gradle builds ( GitHub Actions will validate
- The `isAutoRestartOnCrash`/`isKeepAlive` flags ware removed;any legacy preference stored under their old keys is simply ignored（ accepted edge case for consumers who ran them with ErrorProtect OFF