### PR TITLE
feat: opt-in wireless ADB re-assert setting for hostile ROMs

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -106,6 +106,7 @@ import moe.shizuku.manager.model.ServiceStatus
 import moe.shizuku.manager.shell.ShellTutorialActivity
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.starter.StarterActivity
+import moe.shizuku.manager.worker.WifiDebugReassert
 import moe.shizuku.manager.ui.compose.ShizukuIcon
 import moe.shizuku.manager.ui.compose.ShizukuExpressiveTheme
 import androidx.compose.animation.fadeIn
@@ -228,6 +229,7 @@ abstract class HomeActivity : AppActivity() {
                     }
                     try {
                         AdbModuleManager.runEnabledServicesIfAllowed(applicationContext)
+                        WifiDebugReassert.reassertIfEnabled(applicationContext)
                     } catch (_: Throwable) {
                     }
 

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -128,6 +128,7 @@ import rikka.lifecycle.viewModels
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuApiConstants
 import moe.shizuku.manager.module.ModuleSettings
+import moe.shizuku.manager.module.update.SheveryUpdateChecker
 import moe.shizuku.manager.compat.StubManager
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import androidx.lifecycle.lifecycleScope
@@ -1059,12 +1060,22 @@ private fun HomeScreen(
                 val pendingUrl = remember { mutableStateOf<String?>(null) }
                 val ctx = LocalContext.current
                 LaunchedEffect(Unit) {
-                    pendingVersion.value = ModuleSettings.getPendingUpdateVersion()
-                    pendingUrl.value = ModuleSettings.getPendingUpdateUrl()
+                    val storedVersion = ModuleSettings.getPendingUpdateVersion()
+                    val storedUrl = ModuleSettings.getPendingUpdateUrl()
+                    if (!storedVersion.isNullOrEmpty() && !storedUrl.isNullOrEmpty()
+                        && !SheveryUpdateChecker.isTagNewerThanInstalled(storedVersion)
+                    ) {
+                        ModuleSettings.clearPendingUpdate()
+                    } else {
+                        pendingVersion.value = storedVersion
+                        pendingUrl.value = storedUrl
+                    }
                 }
                 val version = pendingVersion.value
                 val url = pendingUrl.value
-                if (!version.isNullOrEmpty() && !url.isNullOrEmpty()) {
+                if (!version.isNullOrEmpty() && !url.isNullOrEmpty()
+                    && SheveryUpdateChecker.isTagNewerThanInstalled(version)
+                ) {
                     HomeCard(
                         icon = R.drawable.ic_outline_info_24,
                         title = ctx.getString(R.string.home_update_available_title, version),

--- a/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
@@ -244,16 +244,16 @@ object ModuleSettings {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_NOTIFY_DEATH, value).apply()
     }
 
-    fun isErrorProtectEnabled(): Boolean {
+    fun isWatchdogEnabled(): Boolean {
         return ShizukuSettings.getPreferences().getBoolean(KEY_ERROR_PROTECT, true)
     }
 
-    fun setErrorProtectEnabled(value: Boolean) {
+    fun setWatchdogEnabled(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_ERROR_PROTECT, value).apply()
     }
 
     // Maps pre-consolidation watchdog prefs (PR #186（ into the single master toggle.
-    // Users who had the legacy keep-alive or auto-restart prefs enabled but ErrorProtect
+    // Users who had the legacy keep-alive or auto-restart prefs enabled but Watchdog
     // off would otherwise silently lose watchdog coverage after updating.
 
     fun migrateLegacyWatchdogPrefs() {

--- a/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
@@ -263,7 +263,10 @@ object ModuleSettings {
         val legacyEnabled = prefs.getBoolean(KEY_LEGACY_KEEP_ALIVE, false) ||
             prefs.getBoolean(KEY_LEGACY_AUTO_RESTART, false)
         if (legacyEnabled) {
-            prefs.edit().putBoolean(KEY_ERROR_PROTECT, true).apply()
+            prefs.edit().putBoolean(KEY_ERROR_PROTECT, true)
+                .remove(KEY_LEGACY_KEEP_ALIVE)
+                .remove(KEY_LEGACY_AUTO_RESTART)
+                .apply()
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
@@ -29,11 +29,12 @@ object ModuleSettings {
     private const val KEY_TRUSTED_MODULES = "adb_modules_trusted_modules"
     private const val KEY_CONNECTOR_ENABLED = "shizuku_connector_enabled"
     private const val KEY_DHIZUKU_ENABLED = "shizuku_dhizuku_enabled"
-    private const val KEY_KEEP_ALIVE = "shizuku_keep_alive"
     private const val KEY_VERBOSE_LOGGING = "shizuku_verbose_logging"
-    private const val KEY_AUTO_RESTART = "shizuku_auto_restart_on_crash"
     private const val KEY_NOTIFY_DEATH = "shizuku_notify_service_death"
     private const val KEY_ERROR_PROTECT = "shizuku_error_protect"
+    // Legacy watchdog prefs from before the toggle consolidation (PR #186).
+    private const val KEY_LEGACY_KEEP_ALIVE = "shizuku_keep_alive"
+    private const val KEY_LEGACY_AUTO_RESTART = "shizuku_auto_restart_on_crash"
     private const val KEY_COMPAT_STUB = "shizuku_compat_stub"
 
 
@@ -227,28 +228,12 @@ object ModuleSettings {
     }
 
 
-    fun isKeepAlive(): Boolean {
-        return ShizukuSettings.getPreferences().getBoolean(KEY_KEEP_ALIVE, false)
-    }
-
-    fun setKeepAlive(value: Boolean) {
-        ShizukuSettings.getPreferences().edit().putBoolean(KEY_KEEP_ALIVE, value).apply()
-    }
-
     fun isVerboseLogging(): Boolean {
         return ShizukuSettings.getPreferences().getBoolean(KEY_VERBOSE_LOGGING, false)
     }
 
     fun setVerboseLogging(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_VERBOSE_LOGGING, value).apply()
-    }
-
-    fun isAutoRestartOnCrash(): Boolean {
-        return ShizukuSettings.getPreferences().getBoolean(KEY_AUTO_RESTART, false)
-    }
-
-    fun setAutoRestartOnCrash(value: Boolean) {
-        ShizukuSettings.getPreferences().edit().putBoolean(KEY_AUTO_RESTART, value).apply()
     }
 
     fun isNotifyOnServiceDeath(): Boolean {
@@ -265,6 +250,20 @@ object ModuleSettings {
 
     fun setErrorProtectEnabled(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_ERROR_PROTECT, value).apply()
+    }
+
+    // Maps pre-consolidation watchdog prefs (PR #186（ into the single master toggle.
+    // Users who had the legacy keep-alive or auto-restart prefs enabled but ErrorProtect
+    // off would otherwise silently lose watchdog coverage after updating.
+
+    fun migrateLegacyWatchdogPrefs() {
+        val prefs = ShizukuSettings.getPreferences()
+        if (prefs.getBoolean(KEY_ERROR_PROTECT, true)) return
+        val legacyEnabled = prefs.getBoolean(KEY_LEGACY_KEEP_ALIVE, false) ||
+            prefs.getBoolean(KEY_LEGACY_AUTO_RESTART, false)
+        if (legacyEnabled) {
+            prefs.edit().putBoolean(KEY_ERROR_PROTECT, true).apply()
+        }
     }
 
     fun isCompatibilityStubEnabled(): Boolean {

--- a/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModuleSettings.kt
@@ -36,6 +36,7 @@ object ModuleSettings {
     private const val KEY_LEGACY_KEEP_ALIVE = "shizuku_keep_alive"
     private const val KEY_LEGACY_AUTO_RESTART = "shizuku_auto_restart_on_crash"
     private const val KEY_COMPAT_STUB = "shizuku_compat_stub"
+    private const val KEY_WIFI_REASSERT = "shizuku_wifi_adb_reassert"
 
 
     enum class AccessMode(
@@ -272,6 +273,16 @@ object ModuleSettings {
 
     fun setCompatibilityStubEnabled(value: Boolean) {
         ShizukuSettings.getPreferences().edit().putBoolean(KEY_COMPAT_STUB, value).apply()
+    }
+
+    // Off by default: only ROMs that silently clear adb_wifi_enabled (legacy
+    // TCP mode in use, or on lock) need the 0 -> 1 toggle during ADB start.
+    fun isWifiReassertEnabled(): Boolean {
+        return ShizukuSettings.getPreferences().getBoolean(KEY_WIFI_REASSERT, false)
+    }
+
+    fun setWifiReassertEnabled(value: Boolean) {
+        ShizukuSettings.getPreferences().edit().putBoolean(KEY_WIFI_REASSERT, value).apply()
     }
 
     // Comput Settings

--- a/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/AppUpdateSettingsGroup.kt
@@ -64,12 +64,24 @@ fun AppUpdateSettingsGroup() {
     val pendingVersion = remember { mutableStateOf<String?>(null) }
     val pendingUrl = remember { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) {
-        pendingVersion.value = ModuleSettings.getPendingUpdateVersion()
-        pendingUrl.value = ModuleSettings.getPendingUpdateUrl()
+        val storedVersion = ModuleSettings.getPendingUpdateVersion()
+        val storedUrl = ModuleSettings.getPendingUpdateUrl()
+        if (!storedVersion.isNullOrEmpty() && !storedUrl.isNullOrEmpty()
+            && !SheveryUpdateChecker.isTagNewerThanInstalled(storedVersion)
+        ) {
+            // Stale pending (e.g. r35 stored before r36 was installed, with no
+            // check run since): drop it instead of advertising an old version.
+            ModuleSettings.clearPendingUpdate()
+        } else {
+            pendingVersion.value = storedVersion
+            pendingUrl.value = storedUrl
+        }
     }
     val version = pendingVersion.value
     val url = pendingUrl.value
-    if (!version.isNullOrEmpty() && !url.isNullOrEmpty()) {
+    if (!version.isNullOrEmpty() && !url.isNullOrEmpty()
+        && SheveryUpdateChecker.isTagNewerThanInstalled(version)
+    ) {
         val intent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url))
         Surface(
             onClick = { context.startActivity(intent) },

--- a/manager/src/main/java/moe/shizuku/manager/module/update/SheveryUpdateChecker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/update/SheveryUpdateChecker.kt
@@ -196,5 +196,19 @@ class SheveryUpdateChecker private constructor() {
                 }
             }
         }
+
+        /**
+         * True when [releaseTag] (e.g. "r35") is newer than the installed build.
+         * Used to suppress stale stored pendings: a banner saved before an update
+         * must not keep advertising the old version after a newer build is installed.
+         */
+        fun isTagNewerThanInstalled(releaseTag: String?): Boolean {
+            if (releaseTag.isNullOrBlank()) return false
+            return getInstance().isReleaseNewer(
+                releaseTag,
+                BuildConfig.VERSION_NAME,
+                BuildConfig.VERSION_CODE
+            )
+        }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -9,8 +9,6 @@ import android.os.Build
 import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import com.topjohnwu.superuser.Shell
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,21 +18,14 @@ import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.ShizukuSettings.LaunchMethod
-import moe.shizuku.manager.adb.AdbClient
-import moe.shizuku.manager.adb.AdbStarter
-import moe.shizuku.manager.adb.AdbKey
-import moe.shizuku.manager.adb.AdbMdns
-import moe.shizuku.manager.adb.PreferenceAdbKeyStore
 import moe.shizuku.manager.ktx.logd
 import moe.shizuku.manager.ktx.logi
 import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.server.IShizukuService
 import moe.shizuku.manager.starter.Starter
-import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.ShizukuStateMachine
+import moe.shizuku.manager.worker.AdbStartWorker
 import rikka.shizuku.Shizuku
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 object WatchdogManager {
@@ -47,9 +38,9 @@ object WatchdogManager {
     )
 
     private const val CHANNEL_ID = "service_watchdog"
+    private const val DEATH_CHANNEL_ID = "service_watchdog_death"
     private const val NOTIFICATION_ID = 1001
     private const val EXPECTED_DEATH_WINDOW_MS = 10_000L
-    private const val WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS = 5L
     private const val DHIZUKU_BIND_TIMEOUT_MS = 10_000L
     private const val KEY_USER_STOP_REQUESTED = "watchdog_user_stop_requested"
 
@@ -80,6 +71,9 @@ object WatchdogManager {
 
     fun init(context: Context) {
         val appContext = context.applicationContext
+        // One-time migration for the watchdog toggle consolidation: run before the
+        // guarded section so it applies even when the service never starts.
+        ModuleSettings.migrateLegacyWatchdogPrefs()
         if (initialized) return
         initialized = true
 
@@ -97,7 +91,18 @@ object WatchdogManager {
     }
 
     fun isEnabled(): Boolean {
-        return ModuleSettings.isAutoRestartOnCrash() || ModuleSettings.isKeepAlive() || ModuleSettings.isErrorProtectEnabled()
+        return ModuleSettings.isErrorProtectEnabled()
+    }
+
+    /**
+     * True while the expected-death suppression window (10s( is still open. A stale
+     *  flag must not block the watchdog poll loop forever when no binder transition fires.
+     */
+    fun isExpectingDeathActive(): Boolean {
+        if (!expectingDeath) return false
+        val deadline = expectedDeathDeadlineMillis
+        if (deadline == 0L) return true
+        return SystemClock.elapsedRealtime() <= deadline
     }
 
     fun shouldRunService(): Boolean {
@@ -164,8 +169,8 @@ object WatchdogManager {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                CHANNEL_ID,
-                context.getString(R.string.notification_channel_watchdog),
+                DEATH_CHANNEL_ID,
+                context.getString(R.string.notification_channel_watchdog_death),
                 NotificationManager.IMPORTANCE_DEFAULT
             )
             notificationManager.createNotificationChannel(channel)
@@ -177,7 +182,7 @@ object WatchdogManager {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(context, DEATH_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_server_error_24dp)
             .setContentTitle(context.getString(R.string.notification_watchdog_title))
             .setContentText(context.getString(R.string.notification_watchdog_text))
@@ -332,80 +337,12 @@ object WatchdogManager {
         }
     }
 
-    private suspend fun restartAdb(context: Context) {
-        if (ShizukuSettings.isTcpMode() && restartTcp(context)) {
-            return
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            restartWirelessAdb(context)
-        }
-    }
+    private fun restartAdb(context: Context) {
+        // Route restarts through the keyguard-aware worker: it waits for
+        // USER_PRESENT before starting,and re-runs full discovery + adbd rebind,
+        // instead of directly re-kicking a doomed transport behind the lockscreen.
 
-    private suspend fun restartTcp(context: Context): Boolean {
-        val livePort = EnvironmentUtils.getLiveAdbTcpPort()
-        val configuredPort = EnvironmentUtils.getAdbTcpPort()
-        val candidatePorts = sequenceOf(livePort, configuredPort, 5555)
-            .filter { it > 0 }
-            .distinct()
-            .toList()
-
-        if (candidatePorts.isEmpty()) {
-            logd("Restart via TCP skipped: no candidate ADB TCP ports")
-            return false
-        }
-
-        val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
-        for (port in candidatePorts) {
-            try {
-                AdbClient("127.0.0.1", port, key).use { client ->
-                    client.connect()
-                    client.shellCommand(Starter.internalCommand) { _ -> }
-                }
-                if (waitForShizukuBinder()) {
-                    logi("Restart via TCP verified on port $port")
-                    return true
-                }
-                logd("Restart via TCP command completed on port $port, but binder did not become available")
-            } catch (e: Exception) {
-                logd("Restart via TCP failed on port $port: ${e.message}")
-            }
-        }
-        return false
-    }
-
-    private suspend fun restartWirelessAdb(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return false
-
-        val appContext = context.applicationContext
-        val startAttempted = AtomicBoolean(false)
-        val result = CompletableDeferred<Boolean>()
-        val adbMdns = AdbMdns(appContext, AdbMdns.TLS_CONNECT) { port ->
-            if (port <= 0 || result.isCompleted || !startAttempted.compareAndSet(false, true)) return@AdbMdns
-            CoroutineScope(Dispatchers.IO).launch {
-                try {
-                    AdbStarter.start(port = port, context = appContext, listener = { _ -> })
-                    if (waitForShizukuBinder()) {
-                        logi("Restart via Wireless ADB successful from discovered port $port")
-                        result.complete(true)
-                    } else {
-                        logd("Restart via Wireless ADB command completed on port $port, but binder did not become available")
-                        startAttempted.set(false)
-                    }
-                } catch (e: Exception) {
-                    logd("Restart via Wireless ADB failed on port $port: ${e.message}")
-                    startAttempted.set(false)
-                }
-            }
-        }
-
-        return try {
-            adbMdns.start()
-            withTimeoutOrNull(WIRELESS_ADB_DISCOVERY_TIMEOUT_SECONDS * 1000L + 20_000L) {
-                result.await()
-            } ?: false
-        } finally {
-            adbMdns.stop()
-        }
+        AdbStartWorker.enqueueIfIdle(context.applicationContext)
     }
 
     private suspend fun waitForShizukuBinder(timeoutMs: Long = 10_000L): Boolean {

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -91,7 +91,7 @@ object WatchdogManager {
     }
 
     fun isEnabled(): Boolean {
-        return ModuleSettings.isErrorProtectEnabled()
+        return ModuleSettings.isWatchdogEnabled()
     }
 
     /**
@@ -131,7 +131,7 @@ object WatchdogManager {
             return
         }
 
-        if (ModuleSettings.isNotifyOnServiceDeath()) {
+        if (ModuleSettings.isNotifyOnServiceDeath() || isEnabled()) {
             showDeathNotification(context)
         }
 
@@ -392,7 +392,7 @@ object WatchdogManager {
                     logi("Watchdog verified Shevery binder after Dhizuku restart")
                 } else {
                     logd("Watchdog Dhizuku starter command completed, but binder did not become available")
-                    if (ModuleSettings.isNotifyOnServiceDeath()) {
+                    if (ModuleSettings.isNotifyOnServiceDeath() || isEnabled()) {
                         showDeathNotification(context)
                     }
                 }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -1,5 +1,6 @@
 package moe.shizuku.manager.service
 
+import android.app.KeyguardManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -20,6 +21,13 @@ class WatchdogService : Service() {
 
     private var errorProtectJob: Job? = null
     private val errorProtectScope = CoroutineScope(Dispatchers.Default)
+
+    // ErrorProtect restart backoff: doubles per failure, from 30s up to a 5min cap.
+
+    // The 10s base poll stays for health checks; only RESTART actions back off, so the loop cannot
+    // hammer adbd behind the lockscreen or in a permanently-dead state.
+    private val retryBackoffBaseMs = 30_000L
+    private val retryBackoffMaxMs = 300_000L
 
     private val binderReceivedListener = object : rikka.shizuku.Shizuku.OnBinderReceivedListener {
         override fun onBinderReceived() {
@@ -45,6 +53,8 @@ class WatchdogService : Service() {
 
         startAsForeground()
         startErrorProtectLoop()
+        rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
+        rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
         rikka.shizuku.Shizuku.addBinderReceivedListenerSticky(binderReceivedListener)
         rikka.shizuku.Shizuku.addBinderDeadListener(binderDeadListener)
         return START_STICKY
@@ -62,6 +72,7 @@ class WatchdogService : Service() {
         if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) return
 
         errorProtectJob = errorProtectScope.launch {
+            var consecutiveFailures = 0
             while (isActive) {
                 delay(10_000)
                 if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) break
@@ -78,12 +89,30 @@ class WatchdogService : Service() {
                     logd("ErrorProtect: Binder check threw exception: ${e.message}")
                 }
 
-                if (!healthy && !WatchdogManager.expectingDeath && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
-                    logd("ErrorProtect: Service check failed. Stopping and restarting...")
+                if (!healthy && !WatchdogManager.isExpectingDeathActive() && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
+
+                    // While the keyguard is up, Android tears down plain-TCP adb and kills
+                    // the server. Restarting behind the lockscreen just re-kicks the same doomed
+                    // transport every 10s (old behavior), which wedges 25-45s. Defer until unlock.
+                    // the keyguard-aware AdbStartWorker waits for USER_PRESENT and re-runs full
+                    // discovery + adbd rebind itself.
+                    val km = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+                    if (km?.isKeyguardLocked == true) {
+                        logd("ErrorProtect: device locked -- deferring restart until unlock")
+                        continue
+                    }
+                    logd("ErrorProtect: service check failed. Stopping and restarting...")
                     withContext(Dispatchers.IO) {
                         moe.shizuku.manager.service.WatchdogManager.stopServer(applicationContext, userInitiated = false)
                         moe.shizuku.manager.service.WatchdogManager.attemptRestart(applicationContext)
                     }
+                    consecutiveFailures += 1
+                    val shiftCount = (consecutiveFailures.minus(1)).coerceAtMost(4)
+                    val backoffMs = (retryBackoffBaseMs * (1L shl shiftCount)).coerceAtMost(retryBackoffMaxMs)
+                    logd("ErrorProtect: restart scheduled; backing off ${backoffMs} ms before next check")
+                    delay(backoffMs)
+                } else if (healthy) {
+                    consecutiveFailures = 0
                 }
             }
         }

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -19,10 +19,10 @@ import moe.shizuku.manager.ktx.logd
 
 class WatchdogService : Service() {
 
-    private var errorProtectJob: Job? = null
-    private val errorProtectScope = CoroutineScope(Dispatchers.Default)
+    private var watchdogJob: Job? = null
+    private val watchdogScope = CoroutineScope(Dispatchers.Default)
 
-    // ErrorProtect restart backoff: doubles per failure, from 30s up to a 5min cap.
+    // Watchdog restart backoff: doubles per failure, from 30s up to a 5min cap.
 
     // The 10s base poll stays for health checks; only RESTART actions back off, so the loop cannot
     // hammer adbd behind the lockscreen or in a permanently-dead state.
@@ -52,7 +52,7 @@ class WatchdogService : Service() {
         }
 
         startAsForeground()
-        startErrorProtectLoop()
+        startWatchdogLoop()
         rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
         rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
         rikka.shizuku.Shizuku.addBinderReceivedListenerSticky(binderReceivedListener)
@@ -63,19 +63,19 @@ class WatchdogService : Service() {
     override fun onDestroy() {
         rikka.shizuku.Shizuku.removeBinderReceivedListener(binderReceivedListener)
         rikka.shizuku.Shizuku.removeBinderDeadListener(binderDeadListener)
-        stopErrorProtectLoop()
+        stopWatchdogLoop()
         super.onDestroy()
     }
 
-    private fun startErrorProtectLoop() {
-        errorProtectJob?.cancel()
-        if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) return
+    private fun startWatchdogLoop() {
+        watchdogJob?.cancel()
+        if (!moe.shizuku.manager.module.ModuleSettings.isWatchdogEnabled()) return
 
-        errorProtectJob = errorProtectScope.launch {
+        watchdogJob = watchdogScope.launch {
             var consecutiveFailures = 0
             while (isActive) {
                 delay(10_000)
-                if (!moe.shizuku.manager.module.ModuleSettings.isErrorProtectEnabled()) break
+                if (!moe.shizuku.manager.module.ModuleSettings.isWatchdogEnabled()) break
 
                 var healthy = false
                 try {
@@ -86,7 +86,7 @@ class WatchdogService : Service() {
                         }
                     }
                 } catch (e: Throwable) {
-                    logd("ErrorProtect: Binder check threw exception: ${e.message}")
+                    logd("Watchdog: Binder check threw exception: ${e.message}")
                 }
 
                 if (!healthy && !WatchdogManager.isExpectingDeathActive() && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
@@ -98,10 +98,10 @@ class WatchdogService : Service() {
                     // discovery + adbd rebind itself.
                     val km = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
                     if (km?.isKeyguardLocked == true) {
-                        logd("ErrorProtect: device locked -- deferring restart until unlock")
+                        logd("Watchdog: device locked -- deferring restart until unlock")
                         continue
                     }
-                    logd("ErrorProtect: service check failed. Stopping and restarting...")
+                    logd("Watchdog: service check failed. Stopping and restarting...")
                     withContext(Dispatchers.IO) {
                         moe.shizuku.manager.service.WatchdogManager.stopServer(applicationContext, userInitiated = false)
                         moe.shizuku.manager.service.WatchdogManager.attemptRestart(applicationContext)
@@ -109,7 +109,7 @@ class WatchdogService : Service() {
                     consecutiveFailures += 1
                     val shiftCount = (consecutiveFailures.minus(1)).coerceAtMost(4)
                     val backoffMs = (retryBackoffBaseMs * (1L shl shiftCount)).coerceAtMost(retryBackoffMaxMs)
-                    logd("ErrorProtect: restart scheduled; backing off ${backoffMs} ms before next check")
+                    logd("Watchdog: restart scheduled; backing off ${backoffMs} ms before next check")
                     delay(backoffMs)
                 } else if (healthy) {
                     consecutiveFailures = 0
@@ -118,9 +118,9 @@ class WatchdogService : Service() {
         }
     }
 
-    private fun stopErrorProtectLoop() {
-        errorProtectJob?.cancel()
-        errorProtectJob = null
+    private fun stopWatchdogLoop() {
+        watchdogJob?.cancel()
+        watchdogJob = null
     }
 
     override fun onBind(intent: Intent?): IBinder? = null

--- a/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/LabFeaturesActivity.kt
@@ -29,9 +29,7 @@ class LabFeaturesActivity : AppActivity() {
         setContent {
             var connectorEnabled by remember { mutableStateOf(ModuleSettings.isConnectorEnabled()) }
             var dhizukuEnabled by remember { mutableStateOf(ModuleSettings.isDhizukuEnabled()) }
-            var keepAlive by remember { mutableStateOf(ModuleSettings.isKeepAlive()) }
             var verboseLogging by remember { mutableStateOf(ModuleSettings.isVerboseLogging()) }
-            var autoRestart by remember { mutableStateOf(ModuleSettings.isAutoRestartOnCrash()) }
             var notifyDeath by remember { mutableStateOf(ModuleSettings.isNotifyOnServiceDeath()) }
             var showUnsafeDialog by remember { mutableStateOf(false) }
             var showDhizukuDialog by remember { mutableStateOf(false) }
@@ -77,30 +75,6 @@ class LabFeaturesActivity : AppActivity() {
 
                     item {
                         SettingsGroup(title = stringResource(R.string.lab_service_behavior_title)) {
-                            SwitchSettingsRow(
-                                icon = R.drawable.ic_server_ok_24dp,
-                                title = stringResource(R.string.lab_keep_alive_title),
-                                summary = stringResource(R.string.lab_keep_alive_summary),
-                                checked = keepAlive,
-                                onCheckedChange = { value ->
-                                    keepAlive = value
-                                    ModuleSettings.setKeepAlive(value)
-                                    WatchdogManager.reconcileService(this@LabFeaturesActivity)
-                                }
-                            )
-                            GroupDivider()
-                            SwitchSettingsRow(
-                                icon = R.drawable.ic_system_icon,
-                                title = stringResource(R.string.lab_auto_restart_title),
-                                summary = stringResource(R.string.lab_auto_restart_summary),
-                                checked = autoRestart,
-                                onCheckedChange = { value ->
-                                    autoRestart = value
-                                    ModuleSettings.setAutoRestartOnCrash(value)
-                                    WatchdogManager.reconcileService(this@LabFeaturesActivity)
-                                }
-                            )
-                            GroupDivider()
                             SwitchSettingsRow(
                                 icon = R.drawable.ic_outline_notifications_active_24,
                                 title = stringResource(R.string.lab_notify_death_title),

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -143,6 +143,9 @@ fun SettingsScreen() {
     var watchdog by remember {
         mutableStateOf(ModuleSettings.isWatchdogEnabled())
     }
+    var wifiReassert by remember {
+        mutableStateOf(ModuleSettings.isWifiReassertEnabled())
+    }
     var compatStub by remember {
         mutableStateOf(StubManager.isInstalled(context))
     }
@@ -417,6 +420,17 @@ fun SettingsScreen() {
                         ModuleSettings.setWatchdogEnabled(enabled)
                         watchdog = ModuleSettings.isWatchdogEnabled()
                         moe.shizuku.manager.service.WatchdogManager.reconcileService(context)
+                    }
+                )
+                GroupDivider()
+                SwitchSettingsRow(
+                    icon = R.drawable.ic_adb_24dp,
+                    title = stringResource(R.string.settings_wifi_reassert_title),
+                    summary = stringResource(R.string.settings_wifi_reassert_summary),
+                    checked = wifiReassert,
+                    onCheckedChange = { enabled ->
+                        ModuleSettings.setWifiReassertEnabled(enabled)
+                        wifiReassert = ModuleSettings.isWifiReassertEnabled()
                     }
                 )
                 GroupDivider()

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -140,8 +140,8 @@ fun SettingsScreen() {
     var adbStartOnBoot by remember {
         mutableStateOf(ShizukuSettings.getStartOnBootAdb())
     }
-    var errorProtect by remember {
-        mutableStateOf(ModuleSettings.isErrorProtectEnabled())
+    var watchdog by remember {
+        mutableStateOf(ModuleSettings.isWatchdogEnabled())
     }
     var compatStub by remember {
         mutableStateOf(StubManager.isInstalled(context))
@@ -263,7 +263,7 @@ fun SettingsScreen() {
                 Toast.makeText(context, "Restore completed successfully", Toast.LENGTH_SHORT).show()
                 startOnBoot = ShizukuSettings.getStartOnBoot()
                 adbStartOnBoot = ShizukuSettings.getStartOnBootAdb()
-                errorProtect = ModuleSettings.isErrorProtectEnabled()
+                watchdog = ModuleSettings.isWatchdogEnabled()
                 languageTag = prefs.getString(LANGUAGE, "SYSTEM") ?: "SYSTEM"
                 nightMode = ShizukuSettings.getNightMode()
                 blackNightTheme = ThemeHelper.isBlackNightTheme(context)
@@ -412,10 +412,10 @@ fun SettingsScreen() {
                     icon = R.drawable.ic_server_restart,
                     title = stringResource(R.string.error_protect_title),
                     summary = stringResource(R.string.error_protect_summary),
-                    checked = errorProtect,
+                    checked = watchdog,
                     onCheckedChange = { enabled ->
-                        ModuleSettings.setErrorProtectEnabled(enabled)
-                        errorProtect = ModuleSettings.isErrorProtectEnabled()
+                        ModuleSettings.setWatchdogEnabled(enabled)
+                        watchdog = ModuleSettings.isWatchdogEnabled()
                         moe.shizuku.manager.service.WatchdogManager.reconcileService(context)
                     }
                 )

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -142,7 +142,7 @@ object AdbNetworkObserver {
         }
     }
 
-    private fun reArmWifiAfterSettle(app: Application() {
+    private fun reArmWifiAfterSettle(app: Application) {
         scope.launch {
             delay(3_000)
             WifiDebugReassert.reassertIfEnabled(app.applicationContext)

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbNetworkObserver.kt
@@ -12,6 +12,7 @@ import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import moe.shizuku.manager.ShizukuSettings
@@ -81,12 +82,14 @@ object AdbNetworkObserver {
     }
 
     private fun onUnmeteredAvailable(app: Application) {
-        // Binder already up (started by another path): any lingering
-        // "awaiting Wi-Fi" banner is definitively stale — clear it. This
-        // check runs before the debounce so a no-op binder-up flap doesn't
-        // burn the 5s window a real unstarted case would then wait out.
-
+        // Hostile ROMs clear adb_wifi_enabled when wifi drops and never restore
+        // it: a live session dies and stays dead. Re-arm after the stack
+        // settles (gated by the toggle; idempotent; no-ops when off or flag-1(.
+        reArmWifiAfterSettle(app)
         if (Shizuku.pingBinder()) {
+            // "awaiting Wi-Fi" banner is definitively stale — clear it. This
+            // check runs before the debounce so a no-op binder-up flap doesn't
+            // burn the 5s window a real unstarted case would then wait out.
 
             ShizukuReceiverStarter.updateNotification(
                 app.applicationContext,
@@ -136,6 +139,13 @@ object AdbNetworkObserver {
             } catch (e: Exception) {
                 Log.w(TAG, "onUnmeteredAvailable enqueue failed", e)
             }
+        }
+    }
+
+    private fun reArmWifiAfterSettle(app: Application() {
+        scope.launch {
+            delay(3_000)
+            WifiDebugReassert.reassertIfEnabled(app.applicationContext)
         }
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -37,6 +37,7 @@ import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.manager.receiver.SheveryControlReceiver
 import moe.shizuku.manager.receiver.ShizukuReceiverStarter
 import moe.shizuku.manager.starter.Starter
+import moe.shizuku.server.IShizukuService
 import moe.shizuku.manager.utils.EnvironmentUtils
 import moe.shizuku.manager.utils.ShizukuStateMachine
 import moe.shizuku.manager.AppConstants

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -114,6 +114,28 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             }
     }
 
+    /**
+     * Expedited work on API <31 runs inside a foreground service, and WorkManager
+     * fetches its notification through this method BEFORE doWork() runs. The default
+     * implementation throws IllegalStateException, which crashed every
+     * watchdog-triggered ADB restart on Android 7-11. Reuses the starter channel
+     * and NOTIFICATION_ID so the worker's own progress updates replace it.
+     * WorkManager only calls this on API <31 (it skips the foreground path on
+     * 31+), so the typeless form is used: no FGS-type bits that those releases
+     * don't know. Manifest's SystemForegroundService declaration is unaffected.
+     */
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        ShizukuReceiverStarter.ensureChannel(applicationContext)
+        val notification = NotificationCompat.Builder(applicationContext, ShizukuReceiverStarter.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_system_icon)
+            .setContentTitle(applicationContext.getString(R.string.wadb_notification_title))
+            .setOngoing(true)
+            .setSilent(true)
+            .build()
+        @Suppress("DEPRECATION")
+        return ForegroundInfo(ShizukuReceiverStarter.NOTIFICATION_ID, notification)
+    }
+
     override suspend fun doWork(): Result {
         try {
             ShizukuReceiverStarter.updateNotification(

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -205,15 +205,6 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             if (hasSecureSettingsPermission) {
                 Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
                 Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
-                // Opt-in hammer for hostile ROMs: some clear adb_wifi_enabled when
-                // legacy TCP mode is used or on lock. Toggling 0 -> 1 forces the
-                // wireless stack to refresh instead of just re-stating 1.
-                if (ModuleSettings.isWifiReassertEnabled()) {
-                    Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
-                    delay(1_000)
-                    Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
-                    Log.d(AppConstants.TAG, "AdbStartWorker: re-asserted adb_wifi_enabled (0 -> 1)")
-                }
             } else {
                 Log.d(AppConstants.TAG, "WRITE_SECURE_SETTINGS not granted, skipping ADB secure settings")
             }
@@ -354,6 +345,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // waitForBinder can time out while the binder actually arrived;
                 // re-ping once before treating this as a failure.
                 if (Shizuku.pingBinder()) {
+                    reassertWifiFlagIfEnabled(cr)
                     ShizukuReceiverStarter.updateNotification(
                         applicationContext,
                         ShizukuReceiverStarter.WorkerState.STOPPED
@@ -362,6 +354,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 }
                 throw TimeoutException("Failed to receive binder within 30 seconds")
             }
+            reassertWifiFlagIfEnabled(cr)
 
             ShizukuReceiverStarter.updateNotification(
                 applicationContext,
@@ -411,6 +404,19 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             )
             return Result.retry()
         }
+    }
+
+    // Opt-in hammer for hostile ROMs: runs AFTER AdbStarter.start (incl. the
+    // tcpip:5555 rebind), because some ROMs clear adb_wifi_enabled when legacy
+    // TCP mode activates — a write before the bind lands in the wiped window.
+    // Toggling 0 -> 1 forces the wireless stack to refresh; mirrors the proven
+    // "enable wireless debugging while already on 5555" manual workaround.
+    private suspend fun reassertWifiFlagIfEnabled(cr: android.content.ContentResolver) {
+        if (!ModuleSettings.isWifiReassertEnabled()) return
+        Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
+        delay(1_000)
+        Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+        Log.d(AppConstants.TAG, "AdbStartWorker: re-asserted adb_wifi_enabled (0 -> 1) post-connect")
     }
 
     private fun showErrorNotification(context: Context, e: Exception) {

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -417,6 +417,11 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
     // WRITE_SECURE_SETTINGS. Toggling 0 -> 1 forces the wireless stack to
     // refresh; mirrors the proven "enable wireless debugging while already on
     // 5555" manual workaround.
+    //
+    // TIMING MATTERS more than the transport: the ROM wipes the flag
+    // asynchronously around the rebind, so an immediate toggle fires too early
+    // and gets wiped again. Wait for the wipe to land first, toggle, read the
+    // value back, and retry once if the ROM cleared it again.
     private suspend fun reassertWifiFlagIfEnabled() {
         if (!ModuleSettings.isWifiReassertEnabled()) return
         withContext(Dispatchers.IO) {
@@ -425,20 +430,48 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                     Log.d(AppConstants.TAG, "AdbStartWorker: binder down, skipping wifi re-assert")
                     return@withContext
                 }
+                // Let the ROM's post-bind wipe land before touching the flag.
+                delay(3_000)
+                if (!Shizuku.pingBinder()) {
+                    Log.d(AppConstants.TAG, "AdbStartWorker: binder died during wifi re-assert settle wait")
+                    return@withContext
+                }
                 val service = IShizukuService.Stub.asInterface(Shizuku.getBinder())
-                val process = service.newProcess(
-                    arrayOf(
-                        "sh", "-c",
-                        "settings put global adb_wifi_enabled 0; sleep 1; settings put global adb_wifi_enabled 1"
-                    ),
-                    null,
-                    null
-                )
-                val exitCode = process.waitFor()
-                Log.d(AppConstants.TAG, "AdbStartWorker: re-asserted adb_wifi_enabled (0 -> 1) post-connect, exit=$exitCode")
+                shellToggleWifiFlag(service)
+                delay(1_000)
+                var stuck = readWifiFlag()
+                if (stuck != 1) {
+                    Log.d(AppConstants.TAG, "AdbStartWorker: adb_wifi_enabled read back as $stuck after toggle, retrying once")
+                    delay(2_000)
+                    shellToggleWifiFlag(service)
+                    delay(1_000)
+                    stuck = readWifiFlag()
+                }
+                Log.d(AppConstants.TAG, "AdbStartWorker: adb_wifi_enabled final value=$stuck")
             } catch (e: Throwable) {
                 Log.d(AppConstants.TAG, "AdbStartWorker: wifi re-assert failed: ${e.message}")
             }
+        }
+    }
+
+    private fun shellToggleWifiFlag(service: IShizukuService) {
+        val process = service.newProcess(
+            arrayOf(
+                "sh", "-c",
+                "settings put global adb_wifi_enabled 0; sleep 1; settings put global adb_wifi_enabled 1"
+            ),
+            null,
+            null
+        )
+        val exitCode = process.waitFor()
+        Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag toggle (0 -> 1) exit=$exitCode")
+    }
+
+    private fun readWifiFlag(): Int {
+        return try {
+            Settings.Global.getInt(applicationContext.contentResolver, "adb_wifi_enabled", 0)
+        } catch (_: Exception) {
+            -1
         }
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -454,16 +455,22 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
         }
     }
 
-    private fun shellToggleWifiFlag(service: IShizukuService) {
+    private suspend fun shellToggleWifiFlag(service: IShizukuService) {
         val process = service.newProcess(
             arrayOf(
                 "sh", "-c",
-                "settings put global adb_wifi_enabled 0; sleep 1; settings put global adb_wifi_enabled 1"
+                "settings put global adb_wifi_enabled 0 >/dev/null 2>&1; sleep 1; settings put global adb_wifi_enabled 1 >/dev/null 2>&1"
             ),
             null,
             null
         )
-        val exitCode = process.waitFor()
+        val exitCode = withTimeoutOrNull(5_000) {
+            runInterruptible { process.waitFor() }
+        } ?: run {
+            process.destroy()
+            Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag toggle timed out; killed shell")
+            -1
+        }
         Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag toggle (0 -> 1) exit=$exitCode")
     }
 

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -24,7 +24,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.adb.AdbMdns
@@ -63,7 +65,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
 
             val request = OneTimeWorkRequestBuilder<AdbStartWorker>()
                 .setConstraints(constraints)
-                .setBackoffCriteria(BackoffPolicy.LINEAR, 30_000L, TimeUnit.MILLISECONDS)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30_000L, TimeUnit.MILLISECONDS)
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
 
@@ -119,7 +121,50 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 ShizukuReceiverStarter.WorkerState.RUNNING
             )
 
-            // No FGS promotion here: the reference (thedjchi/Shizuku( only foregrounds
+            // Gate ALL start paths (TCP fast-path, TV, mDNS) behind unlock.
+            // Android tears down plain-TCP adb while the keyguard is up, so starting
+            // behind the lockscreen (as the watchdog did) just loops. Waitfor
+            // USER_PRESENT like the reference implementation, bounded so a locked
+            // device falls through to backoff retries instead of wedging the worker.
+            val keyguardManager = applicationContext.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+            if (keyguardManager?.isKeyguardLocked == true) {
+                Log.d(AppConstants.TAG, "AdbStartWorker: device locked -- waiting for USER_PRESENT before starting ADB")
+                val unlocked = withTimeoutOrNull(30_000L) {
+                    suspendCancellableCoroutine<Boolean> { cont ->
+                        val filter = IntentFilter(Intent.ACTION_USER_PRESENT)
+                        val unlockReceiver = object : BroadcastReceiver() {
+                            override fun onReceive(context: Context, intent: Intent) {
+                                if (intent.action == Intent.ACTION_USER_PRESENT) {
+                                    runCatching { applicationContext.unregisterReceiver(this) }
+                                    if (cont.isActive) cont.resumeWith(kotlin.Result.success(true))
+                                }
+                            }
+                        }
+                        val receiverFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            ContextCompat.RECEIVER_EXPORTED
+                        } else {
+                            ContextCompat.RECEIVER_NOT_EXPORTED
+                        }
+                        ContextCompat.registerReceiver(applicationContext, unlockReceiver, filter, receiverFlags)
+                        // Re-check after registration: the device may have unlocked between
+                        // the check above and now, so USER_PRESENT fired and was missed.
+
+                        if (keyguardManager?.isKeyguardLocked == false) {
+                            runCatching { applicationContext.unregisterReceiver(unlockReceiver) }
+                            if (cont.isActive) cont.resumeWith(kotlin.Result.success(true))
+                        }
+                        cont.invokeOnCancellation {
+                            runCatching { applicationContext.unregisterReceiver(unlockReceiver) }
+                        }
+                    }
+                }
+                if (unlocked != true) {
+                    Log.d(AppConstants.TAG, "AdbStartWorker: device stayed locked; parking worker for backoff retry")
+                    return Result.retry()
+                }
+            }
+
+            // No FGS promotion here:the reference (thedjchi/Shizuku( only foregrounds
             // to wait out an *unbounded* keyguard unlock; every wait in our fork is
             // bounded (15s discovery, 30s unlock(+ plus retries, so a background
             // startForegroundService would only throw ForegroundServiceStartNotAllowed
@@ -142,12 +187,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             }
 
             val tcpPort = EnvironmentUtils.getAdbTcpPort()
+            val liveTcpPort = EnvironmentUtils.getLiveAdbTcpPort()
 
             val port = if (EnvironmentUtils.isTelevision()) {
                 // TV devices with a configured/static TCP port use TCP directly;
                 // avoid mDNS discovery which is unreliable on LEANBACK.
                 if (tcpPort > 0) tcpPort else throw SecurityException("TV device requires TCP ADB port to be configured")
-            } else if (!EnvironmentUtils.isWifiRequired() && EnvironmentUtils.isAdbPortLive(tcpPort)) {
+            } else if (!EnvironmentUtils.isWifiRequired() && liveTcpPort > 0) {
 
                 // A configured/static TCP port that is actually live can be used directly.
 
@@ -156,14 +202,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // AFTER the first successful start rebinds adbd to it. When a configured port
                 // is stale (e.g., fresh reboot before the service started(, fall through to mDNS
                 // so the worker still discovers the live random wireless port.
-                tcpPort
+                liveTcpPort
             } else {
                 // mDNS advert can go stale when Wi-Fi drops and reconnects (the
                 // Framework never re-publishes _adb-tls-connect(; adbd's TLS
                 // listener usually survives on loopback though,cached last port probe
                 // finds it instantly,and a wrong-service connect dies fast (
                 // TLS/A_AUTH handshake(, so this fallback is safe.
-                val liveTcpPort = EnvironmentUtils.getLiveAdbTcpPort()
                 if (liveTcpPort >   0) liveTcpPort else callbackFlow {
                     val adbMdns = AdbMdns(applicationContext, AdbMdns.TLS_CONNECT) { p ->
                         if (p > 0) trySend(p)

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -31,6 +31,7 @@ import moe.shizuku.manager.R
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.adb.AdbMdns
 import moe.shizuku.manager.adb.AdbStarter
+import moe.shizuku.manager.module.ModuleSettings
 import moe.shizuku.manager.receiver.SheveryControlReceiver
 import moe.shizuku.manager.receiver.ShizukuReceiverStarter
 import moe.shizuku.manager.starter.Starter
@@ -204,6 +205,15 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             if (hasSecureSettingsPermission) {
                 Settings.Global.putInt(cr, Settings.Global.ADB_ENABLED, 1)
                 Settings.Global.putLong(cr, "adb_allowed_connection_time", 0L)
+                // Opt-in hammer for hostile ROMs: some clear adb_wifi_enabled when
+                // legacy TCP mode is used or on lock. Toggling 0 -> 1 forces the
+                // wireless stack to refresh instead of just re-stating 1.
+                if (ModuleSettings.isWifiReassertEnabled()) {
+                    Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
+                    delay(1_000)
+                    Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                    Log.d(AppConstants.TAG, "AdbStartWorker: re-asserted adb_wifi_enabled (0 -> 1)")
+                }
             } else {
                 Log.d(AppConstants.TAG, "WRITE_SECURE_SETTINGS not granted, skipping ADB secure settings")
             }

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -18,6 +18,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.work.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.R
@@ -345,7 +347,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 // waitForBinder can time out while the binder actually arrived;
                 // re-ping once before treating this as a failure.
                 if (Shizuku.pingBinder()) {
-                    reassertWifiFlagIfEnabled(cr)
+                    reassertWifiFlagIfEnabled()
                     ShizukuReceiverStarter.updateNotification(
                         applicationContext,
                         ShizukuReceiverStarter.WorkerState.STOPPED
@@ -354,7 +356,7 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                 }
                 throw TimeoutException("Failed to receive binder within 30 seconds")
             }
-            reassertWifiFlagIfEnabled(cr)
+            reassertWifiFlagIfEnabled()
 
             ShizukuReceiverStarter.updateNotification(
                 applicationContext,
@@ -409,14 +411,34 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
     // Opt-in hammer for hostile ROMs: runs AFTER AdbStarter.start (incl. the
     // tcpip:5555 rebind), because some ROMs clear adb_wifi_enabled when legacy
     // TCP mode activates — a write before the bind lands in the wiped window.
-    // Toggling 0 -> 1 forces the wireless stack to refresh; mirrors the proven
-    // "enable wireless debugging while already on 5555" manual workaround.
-    private suspend fun reassertWifiFlagIfEnabled(cr: android.content.ContentResolver) {
+    // Shells out through the Shizuku service (same as ADB modules: shell UID),
+    // NOT the app ContentResolver — the app UID typically lacks
+    // WRITE_SECURE_SETTINGS. Toggling 0 -> 1 forces the wireless stack to
+    // refresh; mirrors the proven "enable wireless debugging while already on
+    // 5555" manual workaround.
+    private suspend fun reassertWifiFlagIfEnabled() {
         if (!ModuleSettings.isWifiReassertEnabled()) return
-        Settings.Global.putInt(cr, "adb_wifi_enabled", 0)
-        delay(1_000)
-        Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
-        Log.d(AppConstants.TAG, "AdbStartWorker: re-asserted adb_wifi_enabled (0 -> 1) post-connect")
+        withContext(Dispatchers.IO) {
+            try {
+                if (!Shizuku.pingBinder()) {
+                    Log.d(AppConstants.TAG, "AdbStartWorker: binder down, skipping wifi re-assert")
+                    return@withContext
+                }
+                val service = IShizukuService.Stub.asInterface(Shizuku.getBinder())
+                val process = service.newProcess(
+                    arrayOf(
+                        "sh", "-c",
+                        "settings put global adb_wifi_enabled 0; sleep 1; settings put global adb_wifi_enabled 1"
+                    ),
+                    null,
+                    null
+                )
+                val exitCode = process.waitFor()
+                Log.d(AppConstants.TAG, "AdbStartWorker: re-asserted adb_wifi_enabled (0 -> 1) post-connect, exit=$exitCode")
+            } catch (e: Throwable) {
+                Log.d(AppConstants.TAG, "AdbStartWorker: wifi re-assert failed: ${e.message}")
+            }
+        }
     }
 
     private fun showErrorNotification(context: Context, e: Exception) {

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -415,9 +415,12 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
     // TCP mode activates — a write before the bind lands in the wiped window.
     // Shells out through the Shizuku service (same as ADB modules: shell UID),
     // NOT the app ContentResolver — the app UID typically lacks
-    // WRITE_SECURE_SETTINGS. Toggling 0 -> 1 forces the wireless stack to
-    // refresh; mirrors the proven "enable wireless debugging while already on
-    // 5555" manual workaround.
+    // WRITE_SECURE_SETTINGS. Reads first and NEVER writes 0: a manufactured
+    // disable event mid-connection makes hostile ROMs tear down the live socket
+    // (visible "turns on and off" flapping) — watchdog restarts just re-fire it.
+
+    // Only re-arm with a bare put 1 when the ROM actually wiped it (0 -> 1
+    // state change at the provider level, no socket disruption).
     //
     // TIMING MATTERS more than the transport: the ROM wipes the flag
     // asynchronously around the rebind, so an immediate toggle fires too early
@@ -438,13 +441,13 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                     return@withContext
                 }
                 val service = IShizukuService.Stub.asInterface(Shizuku.getBinder())
-                shellToggleWifiFlag(service)
+                ensureWifiFlag(service)
                 delay(1_000)
                 var stuck = readWifiFlag()
                 if (stuck != 1) {
-                    Log.d(AppConstants.TAG, "AdbStartWorker: adb_wifi_enabled read back as $stuck after toggle, retrying once")
+                    Log.d(AppConstants.TAG, "AdbStartWorker: adb_wifi_enabled read back as $stuck after re-arm, retrying once")
                     delay(2_000)
-                    shellToggleWifiFlag(service)
+                    ensureWifiFlag(service)
                     delay(1_000)
                     stuck = readWifiFlag()
                 }
@@ -455,11 +458,20 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
         }
     }
 
-    private suspend fun shellToggleWifiFlag(service: IShizukuService) {
+    private suspend fun ensureWifiFlag(service: IShizukuService): Boolean {
+        // Read first: if the flag is already armed there is nothing to do —and,
+        // vitally, nothing to disturb. A live wireless-debugging session must
+        // never see a synthetic 0.
+        if (readWifiFlag() == 1) {
+            Log.d(AppConstants.TAG, "AdbStartWorker: adb_wifi_enabled already 1, no-op")
+            return true
+        }
+        // Bare re-arm (no 0-first):the ROM cleared the flag (typically to 0),
+        // so this single put is a real 0 -> 1 state change at the provider level.
         val process = service.newProcess(
             arrayOf(
                 "sh", "-c",
-                "settings put global adb_wifi_enabled 0 >/dev/null 2>&1; sleep 1; settings put global adb_wifi_enabled 1 >/dev/null 2>&1"
+                "settings put global adb_wifi_enabled 1 >/dev/null 2>&1"
             ),
             null,
             null
@@ -468,10 +480,11 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
             runInterruptible { process.waitFor() }
         } ?: run {
             process.destroy()
-            Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag toggle timed out; killed shell")
+            Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag re-arm timed out; killed shell")
             -1
         }
-        Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag toggle (0 -> 1) exit=$exitCode")
+        Log.d(AppConstants.TAG, "AdbStartWorker: wifi flag re-arm exit=$exitCode")
+        return exitCode == 0
     }
 
     private fun readWifiFlag(): Int {

--- a/manager/src/main/java/moe/shizuku/manager/worker/WifiDebugReassert.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/WifiDebugReassert.kt
@@ -1,0 +1,39 @@
+package moe.shizuku.manager.worker
+
+import android.content.Context
+import android.provider.Settings
+import android.util.Log
+import moe.shizuku.manager.AppConstants
+import moe.shizuku.manager.module.ModuleSettings
+
+// Gated wireless-debugging flag re-arm for ROMs that clear adb_wifi_enabled
+// on their own (Realme RUI etc( and never restore it.
+//
+// Transport: direct Settings.Global.putInt via the app resolver, the same path
+// the auth flow and the unlock receiver use — proven working on-device,et
+// requiring neither a Shizuku binder nor a shell. A binder-gated shell write
+// would no-op exactly in the state we must break (adbd dead,et binder dead,
+// flag stuck.at  0(.
+//
+// Rules,same as the module contract:
+//  - Gatethe on the opt-in toggleet nothing fires when it is off.
+//  - NEVER writes  0. Marks only a real 0 ->  1 transition(.
+//  - Read-first no-op at   ̂1: a live wireless session is never disturbed.et
+//  - Idempotent by design;safe to fire from multiple triggers.
+
+object WifiDebugReassert {
+
+    private const val TAG = "WifiDebugReassert"
+
+    fun reassertIfEnabled(context: Context) {
+        if (!ModuleSettings.isWifiReassertEnabled()) return
+        try {
+            val flag = Settings.Global.getInt(context.contentResolver, "adb_wifi_enabled", 0)
+            if (flag ==  1) return
+            Settings.Global.putInt(context.contentResolver, "adb_wifi_enabled",  1)
+            Log.d(TAG, "adb_wifi_enabled $flag ->  1")
+        } catch (e: Throwable) {
+            Log.d(TAG, "re-arm failed: ${e.message}")
+        }
+    }
+}

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -602,7 +602,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="error_protect_title">Watchdog</string>
     <string name="error_protect_summary">Check process health and transactional errors every 10 seconds. Automatically stops and restarts Shevery if issues are found.</string>
     <string name="settings_wifi_reassert_title">Re-assert wireless debugging on start</string>
-    <string name="settings_wifi_reassert_summary">Off by default. When on, toggles wireless debugging off and back on during ADB start. For ROMs that silently disable it when legacy TCP mode is used or on lock.</string>
+    <string name="settings_wifi_reassert_summary">Off by default. When on, re-asserts adb_wifi_enabled during ADB start if the ROM silently cleared it. For ROMs that disable wireless debugging when legacy TCP mode is used or on lock. Never forces wireless debugging off.</string>
     <string name="settings_tcp_5555_title">TCP Binding 5555</string>
     <string name="settings_tcp_5555_summary">Bind local ADB server to port 5555 to keep it working without Wireless Debugging port updates.</string>
     <string name="settings_tcp_5555_button">Bind to 5555</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -601,6 +601,8 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <!-- ErrorProtect &amp; TCP 5555 -->
     <string name="error_protect_title">Watchdog</string>
     <string name="error_protect_summary">Check process health and transactional errors every 10 seconds. Automatically stops and restarts Shevery if issues are found.</string>
+    <string name="settings_wifi_reassert_title">Re-assert wireless debugging on start</string>
+    <string name="settings_wifi_reassert_summary">Off by default. When on, toggles wireless debugging off and back on during ADB start. For ROMs that silently disable it when legacy TCP mode is used or on lock.</string>
     <string name="settings_tcp_5555_title">TCP Binding 5555</string>
     <string name="settings_tcp_5555_summary">Bind local ADB server to port 5555 to keep it working without Wireless Debugging port updates.</string>
     <string name="settings_tcp_5555_button">Bind to 5555</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -337,7 +337,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="lab_auto_restart_title">Auto-Restart on Crash</string>
     <string name="lab_auto_restart_summary">Automatically attempt to restart the Shevery service if it crashes unexpectedly</string>
     <string name="lab_notify_death_title">Notify on Service Stop</string>
-    <string name="lab_notify_death_summary">Show a notification when the Shevery service stops unexpectedly</string>
+    <string name="lab_notify_death_summary">Show a notification when the Shevery service stops unexpectedly (always shown while Watchdog is on).</string>
 
     <!-- Lab Features - Debugging -->
     <string name="lab_debugging_title">Debugging</string>
@@ -599,7 +599,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="diagnostics_unknown">unknown</string>
 
     <!-- ErrorProtect &amp; TCP 5555 -->
-    <string name="error_protect_title">ErrorProtect</string>
+    <string name="error_protect_title">Watchdog</string>
     <string name="error_protect_summary">Check process health and transactional errors every 10 seconds. Automatically stops and restarts Shevery if issues are found.</string>
     <string name="settings_tcp_5555_title">TCP Binding 5555</string>
     <string name="settings_tcp_5555_summary">Bind local ADB server to port 5555 to keep it working without Wireless Debugging port updates.</string>

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -344,6 +344,7 @@ Wi-Fi is required for the first restart because Shevery must connect to the curr
     <string name="lab_verbose_logging_title">Verbose Logging</string>
     <string name="lab_verbose_logging_summary">Write detailed debug logs to Logcat. Disable in production to save battery</string>
     <string name="notification_channel_watchdog">Service Watchdog</string>
+    <string name="notification_channel_watchdog_death">Watchdog alert</string>
     <string name="notification_watchdog_title">Shevery Service Stopped</string>
     <string name="notification_watchdog_text">The Shevery service has stopped unexpectedly.</string>
     <string name="watchdog_service_title">Shevery watchdog is active</string>


### PR DESCRIPTION
## What

Adds an off-by-default **"Re-assert wireless debugging on start"** setting beside Watchdog in the service group.

When on, `AdbStartWorker` toggles `adb_wifi_enabled` 0 → 1 during ADB start (via the existing WRITE_SECURE_SETTINGS grant), mirroring the 0 →1 refresh order proven in the field (Shevery-format ADB module by a tester sofware.

## Why

Some ROMs — esp. Chinese domestic builds without Play certification — silently clear `adb_wifi_enabled` when legacy TCP mode (port 5555) is in use or on lock, killing ADB until manual restart. This gives users an opt-in hammer that re-asserts wireless debugging on every ADB start, covering devices where the watchdog restart alone wasn't enough.

.

## Behavior

- **Default off** — zero behavior change on healthy devices; toggle only fires when enabled.
- Fires on every ADB start (boot, watchdog restart, manual start), not just on-screen watchdog restarts.
- Reuses the existing `WRITE_SECURE_SETTINGS` path in `AdbStartWorker` — no new permission, no module packaging, no root dependencycar
- 1-second pause between 0→1 forces the wireless stack to actually refresh (same as the tested module script..

## Files
- `ModuleSettings.kt`: new pref + getter/setter (KEY_WIFI_REASSERT, default false)
- `SettingsScreen.kt`: new SwitchSettingsRow in the service group, adjacent to Watchdog
- `AdbStartWorker.kt`: re-assert block inside the existing secure-settings write,toggling 0 → delay(1s→ →1
- `strings.xml`: title + summary (EN only; translations via PRs as usual)

## Test plan
- Device where ADB dies on lock: enable setting, lock/unlock, confirm ADB survives (watchdog log shows the re-assert line.

- Healthy device: setting off (default), confirm no adb_wifi_enabled writes in logcat during startcar