### PR TITLE
fix: preserve Home/Modules/Settings scroll position across tab switches

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -251,6 +252,15 @@ abstract class HomeActivity : AppActivity() {
             val settingsListState = rememberSaveable(saver = LazyListState.Saver) {
                 LazyListState()
             }
+            val modulesListState = rememberSaveable(saver = LazyListState.Saver) {
+                LazyListState()
+            }
+            val computListState = rememberSaveable(saver = LazyListState.Saver) {
+                LazyListState()
+            }
+            val homeListState = rememberSaveable(saver = LazyListState.Saver) {
+                LazyListState()
+            }
 
             ShizukuExpressiveTheme {
                 Box(Modifier.fillMaxSize()) {
@@ -314,15 +324,17 @@ abstract class HomeActivity : AppActivity() {
                                         requestLocalNetworkPermission { permissionRefreshTick.intValue++ }
                                     },
                                     onStartDhizuku = { startDhizukuMode() },
-                                    dhizukuEnabled = ModuleSettings.isDhizukuEnabled()
+                                    dhizukuEnabled = ModuleSettings.isDhizukuEnabled(),
+                                    listState = homeListState
                                 )
                                 1 -> moe.shizuku.manager.module.ModulesScreen(onOpenWebUi = {
                                     startActivity(
                                         Intent(this@HomeActivity, moe.shizuku.manager.module.ModuleWebViewActivity::class.java)
                                             .putExtra(moe.shizuku.manager.module.ModuleWebViewActivity.EXTRA_MODULE_ID, it)
-                                    )
-                                })
-                                2 -> moe.shizuku.manager.logs.ComputScreen()
+                                    ),
+                                    listState = modulesListState
+                                )
+                                2 -> moe.shizuku.manager.logs.ComputScreen(listState = computListState)
                                 3 -> moe.shizuku.manager.settings.SettingsScreen(listState = settingsListState)
                             }
                         }
@@ -982,7 +994,8 @@ private fun HomeScreen(
     onCopyDiagnostics: (String) -> Unit,
     onRequestLocalNetworkPermission: () -> Unit,
     onStartDhizuku: () -> Unit,
-    dhizukuEnabled: Boolean
+    dhizukuEnabled: Boolean,
+    listState: LazyListState = rememberLazyListState()
 ) {
     val context = LocalContext.current
     val status = serviceResource?.data ?: ServiceStatus()
@@ -1039,6 +1052,7 @@ private fun HomeScreen(
                 indicator = {}
             ) {
                 LazyColumn(
+                    state = listState,
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 112.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -331,7 +331,8 @@ abstract class HomeActivity : AppActivity() {
                                     startActivity(
                                         Intent(this@HomeActivity, moe.shizuku.manager.module.ModuleWebViewActivity::class.java)
                                             .putExtra(moe.shizuku.manager.module.ModuleWebViewActivity.EXTRA_MODULE_ID, it)
-                                    ),
+                                    )
+                                },
                                     listState = modulesListState
                                 )
                                 2 -> moe.shizuku.manager.logs.ComputScreen(listState = computListState)

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -74,8 +74,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -246,8 +248,8 @@ abstract class HomeActivity : AppActivity() {
 
             var selectedTab by remember { mutableIntStateOf(0) }
 
-            // Hoisted above the AnimatedContent tab switch: SettingsScreen leaves
-            // composition on tab change, so state kept here survives; saveable
+            // Hoisted above the AnimatedContent tab switch: tab screens leave
+            // composition on change, so state kept here survives; saveable
             // so it also survives rotation.
             val settingsListState = rememberSaveable(saver = LazyListState.Saver) {
                 LazyListState()
@@ -257,6 +259,9 @@ abstract class HomeActivity : AppActivity() {
             }
             val computListState = rememberSaveable(saver = LazyListState.Saver) {
                 LazyListState()
+            }
+            val cachedModules = remember {
+                mutableStateOf<List<moe.shizuku.manager.module.AdbModule>>(emptyList(), neverEqualPolicy())
             }
             val homeListState = rememberSaveable(saver = LazyListState.Saver) {
                 LazyListState()
@@ -333,7 +338,8 @@ abstract class HomeActivity : AppActivity() {
                                             .putExtra(moe.shizuku.manager.module.ModuleWebViewActivity.EXTRA_MODULE_ID, it)
                                     )
                                 },
-                                    listState = modulesListState
+                                    listState = modulesListState,
+                                    modulesState = cachedModules
                                 )
                                 2 -> moe.shizuku.manager.logs.ComputScreen(listState = computListState)
                                 3 -> moe.shizuku.manager.settings.SettingsScreen(listState = settingsListState)

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -244,6 +245,13 @@ abstract class HomeActivity : AppActivity() {
 
             var selectedTab by remember { mutableIntStateOf(0) }
 
+            // Hoisted above the AnimatedContent tab switch: SettingsScreen leaves
+            // composition on tab change, so state kept here survives; saveable
+            // so it also survives rotation.
+            val settingsListState = rememberSaveable(saver = LazyListState.Saver) {
+                LazyListState()
+            }
+
             ShizukuExpressiveTheme {
                 Box(Modifier.fillMaxSize()) {
                 Scaffold(
@@ -315,7 +323,7 @@ abstract class HomeActivity : AppActivity() {
                                     )
                                 })
                                 2 -> moe.shizuku.manager.logs.ComputScreen()
-                                3 -> moe.shizuku.manager.settings.SettingsScreen()
+                                3 -> moe.shizuku.manager.settings.SettingsScreen(listState = settingsListState)
                             }
                         }
                     }

--- a/manager/src/main/java/moe/shizuku/manager/logs/ComputScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/logs/ComputScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -162,7 +163,9 @@ private val ComputSpring = spring<Float>(
 )
 
 @Composable
-fun ComputScreen() {
+fun ComputScreen(
+    listState: LazyListState = rememberLazyListState()
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -590,6 +593,7 @@ fun ComputScreen() {
                 .padding(innerPadding)
         ) {
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .widthIn(max = 840.dp)
                     .fillMaxWidth()

--- a/manager/src/main/java/moe/shizuku/manager/module/ModulesScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModulesScreen.kt
@@ -68,9 +68,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -131,14 +131,15 @@ private val MODULE_MIME_TYPES = arrayOf(
 @Composable
 fun ModulesScreen(
     onOpenWebUi: (String) -> Unit,
-    listState: LazyListState = rememberLazyListState()
+    listState: LazyListState = rememberLazyListState(),
+    modulesState: MutableState<List<AdbModule>>
 ) {
     val context = LocalContext.current
     val view = LocalView.current
     val scope = rememberCoroutineScope()
     var selectedTab by remember { mutableStateOf(0) } // 0: Installed, 1: Catalog
     var showCatalog by remember { mutableStateOf(false) }
-    var modules by remember { mutableStateOf<List<AdbModule>>(emptyList(), neverEqualPolicy()) }
+    var modules by modulesState
     var checkingUpdates by remember { mutableStateOf(false) }
     var updatingModuleId by remember { mutableStateOf<String?>(null) }
     var output by remember { mutableStateOf<Pair<String, String>?>(null) }

--- a/manager/src/main/java/moe/shizuku/manager/module/ModulesScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/module/ModulesScreen.kt
@@ -43,7 +43,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -127,7 +129,10 @@ private val MODULE_MIME_TYPES = arrayOf(
 )
 
 @Composable
-fun ModulesScreen(onOpenWebUi: (String) -> Unit) {
+fun ModulesScreen(
+    onOpenWebUi: (String) -> Unit,
+    listState: LazyListState = rememberLazyListState()
+) {
     val context = LocalContext.current
     val view = LocalView.current
     val scope = rememberCoroutineScope()
@@ -281,6 +286,7 @@ fun ModulesScreen(onOpenWebUi: (String) -> Unit) {
             title = stringResource(R.string.modules_title),
             onNavigateUp = null,
             bottomInset = 112.dp,
+            listState = listState,
             isRefreshing = checkingUpdates,
             onRefresh = if (selectedTab == 0) ({
                 view.performHapticFeedback(android.view.HapticFeedbackConstants.CONFIRM)

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -100,7 +102,9 @@ import moe.shizuku.manager.utils.BackupRestoreUtil
 
 
 @Composable
-fun SettingsScreen() {
+fun SettingsScreen(
+    listState: LazyListState = rememberLazyListState()
+) {
     val context = LocalContext.current
     val activity = context as? Activity
     val packageManager = context.packageManager
@@ -341,7 +345,8 @@ fun SettingsScreen() {
         ShizukuLazyScaffold(
             title = stringResource(R.string.settings_title),
             onNavigateUp = null,
-            bottomInset = 112.dp
+            bottomInset = 112.dp,
+            listState = listState
         ) {
         item {
             SettingsGroup(title = stringResource(R.string.settings_application)) {

--- a/manager/src/main/java/moe/shizuku/manager/ui/compose/ShizukuExpressive.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ui/compose/ShizukuExpressive.kt
@@ -50,6 +50,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -393,6 +395,7 @@ fun ShizukuLazyScaffold(
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(10.dp),
     isRefreshing: Boolean = false,
     onRefresh: (() -> Unit)? = null,
+    listState: LazyListState = rememberLazyListState(),
     content: LazyListScope.() -> Unit
 ) {
     ShizukuScaffold(
@@ -406,6 +409,7 @@ fun ShizukuLazyScaffold(
         val navigationBarPadding = WindowInsets.navigationBars.asPaddingValues()
         val list = @Composable {
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding),


### PR DESCRIPTION
Hoists LazyListStates + module list above the AnimatedContent tab switch. Verified: dry merge-tree with dev clean, CI on branch green for prior commit.