### PR TITLE
fix(settings): retitle duplicate Application group to Update

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -622,8 +622,7 @@ fun SettingsScreen(
         }
 
         item {
-            SettingsGroup(title = stringResource(R.string.settings_application)) {
-                SectionHeader(stringResource(R.string.settings_update_group_title))
+            SettingsGroup(title = stringResource(R.string.settings_update_group_title)) {
                 SettingsRow(
                     icon = R.drawable.ic_settings_outline_24dp,
                     title = stringResource(R.string.update_settings_title),


### PR DESCRIPTION
Fixes two settings sections both announcing as **Application**.

Root cause: ad91159 split the update-settings row out of the Application group (Startup + Service Maintenance) but copy-pasted the same group title, leaving a second "Application" heading two items later — confusing for sighted users and TalkBack alike.

Change:
- New group retitled to `settings_update_group_title` ("Update").
- Dropped the now-redundant inner `SectionHeader` (same string, same position, one row below the group title).

String already exists in all 65 locales — no translation work.