### PR TITLE
fix(settings): split Language and Appearance into separate groups

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -499,8 +499,7 @@ fun SettingsScreen(
         }
 
         item {
-            SettingsGroup(title = stringResource(R.string.settings_appearance)) {
-                SectionHeader(stringResource(R.string.settings_language))
+            SettingsGroup(title = stringResource(R.string.settings_language)) {
                 SettingsRow(
                     icon = R.drawable.ic_outline_translate_24,
                     title = stringResource(R.string.settings_language),
@@ -528,8 +527,11 @@ fun SettingsScreen(
                         CustomTabsHelper.launchUrlOrCopy(context, context.getString(R.string.translation_url))
                     }
                 )
-                GroupDivider()
-                SectionHeader(stringResource(rikka.core.R.string.dark_theme))
+            }
+        }
+
+        item {
+            SettingsGroup(title = stringResource(R.string.settings_appearance)) {
                 SettingsRow(
                     icon = R.drawable.ic_outline_dark_mode_24,
                     title = stringResource(rikka.core.R.string.dark_theme),


### PR DESCRIPTION
Fixes the nested groups that made TalkBack announce "Appearance" then "Language" then all the rows — including the dark-theme ones — so everything sounded like it was under Language.

Appearance is now a flat group containing only the dark-theme rows (dark mode, black night, system color(); Language is a separate flat group (language picker, translation contributors, translation link. Both header rows announce clearly and the nesting is gone.



This is the second half of the settings-structure cleanup: #195 retitled the duplicate "Application" group to "Update" ((landed with #195 merged); this commit weaves the Appearance/Language group that #195 did not touch into two proper groups. Matches upstream Shizuku's two flat categories (Language, User interface(.