### PR TITLE
fix(ui): re-assert system bar icons on every resume

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
@@ -51,11 +51,27 @@ abstract class AppActivity : MaterialActivity() {
         // are already resolved — re-write the appearance from them, which makes a Follow-System
         // switch take effect immediately on a theme change, without needing a process restart.
         if (isDecorView) {
-            val controller = WindowCompat.getInsetsController(window, window.decorView)
-            val light = !resources.configuration.isNight()
-            controller.setAppearanceLightStatusBars(light)
-            controller.setAppearanceLightNavigationBars(light)
+            reassertSystemBars()
         }
+    }
+
+    /**
+     * Follow-System can flip the night mode while the activity is already alive (auto-dark /
+     * QS tile(, and a stopped activity isn't always recreated for uiMode — the system bar icons
+     * would then stay on the old appearance while the content follows live. Re-derive them from
+     * whatever configuration the content is rendering with, on every resume and the decor pass..
+     */
+    private fun reassertSystemBars() {
+        if (window.decorView == null) return
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        val light = !resources.configuration.isNight()
+        controller.setAppearanceLightStatusBars(light)
+        controller.setAppearanceLightNavigationBars(light)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        reassertSystemBars()
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
@@ -1,31 +1,37 @@
 package moe.shizuku.manager.app
 
+import android.content.res.Configuration
+import android.content.res.Resources
 import android.content.res.Resources.Theme
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.WindowCompat
 import moe.shizuku.manager.R
 import rikka.core.res.isNight
 import rikka.material.app.MaterialActivity
 
+private const val TAG = "SheverySB"
+
 abstract class AppActivity : MaterialActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Run enableEdgeToEdge after super.onCreate: SystemBarStyle.auto's dark detection
-        // reads the activity's (resolved( resources (EdgeToEdge passes view.getResources()),
-        // so it must see the AppCompat-resolved night mode — running it before super.onCreate
-        // can capture the stale pre-resolution configuration, leaving the bars on the old
-        // icon appearance after a theme switch until the process restarts.
 
+        // Run enableEdgeToEdge after super.onCreate. The icon appearance comes from the
+        // AppCompat night-mode decision (see isAppDark(,NOT from the activity resources config,
+        // which can lag the rendered theme after a forced Light/Dark switch and leave the bars
+        // on the stale (system( appearance (white icons on light(.
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
+            statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) { isAppDark() },
+            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) { isAppDark() }
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+
             window.isNavigationBarContrastEnforced = false
         }
     }
@@ -35,6 +41,7 @@ abstract class AppActivity : MaterialActivity() {
     }
 
     override fun onApplyUserThemeResource(theme: Theme, isDecorView: Boolean) {
+
         if (ThemeHelper.isUsingSystemColor()) {
             if (resources.configuration.isNight())
                 theme.applyStyle(R.style.ThemeOverlay_DynamicColors_Dark, true)
@@ -45,36 +52,69 @@ abstract class AppActivity : MaterialActivity() {
         theme.applyStyle(ThemeHelper.getThemeStyleRes(this), true)
 
         // Re-assert the bar icon appearance on the decor pass: enableEdgeToEdge's auto
-        // style computes once when the window is wired up, and a theme-driven recreate can
-        // leave a stale legacy window flag (API≤29( — the bars keep the old icons until the
-        // process restarts. This pass runs after the theme dispatch, so the activity's resources
-        // are already resolved — re-write the appearance from them, which makes a Follow-System
-        // switch take effect immediately on a theme change, without needing a process restart.
+        // style computes once when the window is wired up,anda theme-driven recreate can
+        // leave a stale legacy window flag(API≤29( —the bars keep the old icons until the
+        // process restarts. This pass runs after the theme dispatch,so the appearance re-write
+        // makes a Follow-System switch take effect immediately on a theme change.
+
         if (isDecorView) {
             reassertSystemBars()
         }
     }
 
     /**
-     * Follow-System can flip the night mode while the activity is already alive (auto-dark /
-     * QS tile(, and a stopped activity isn't always recreated for uiMode — the system bar icons
-     * would then stay on the old appearance while the content follows live. Re-derive them from
-     * whatever configuration the content is rendering with, on every resume and the decor pass..
+     * Re-assert every decor pass and resume: Follow-System can flip the night mode whilethe
+     * activity is alive (auto-dark / QS tile(,and a stopped activity isn't always recreated for uiMode;
+     * without a re-assertthe bars would keep the old icon appearance whilethe content follows live.
+
      */
-    private fun reassertSystemBars() {
+
+    /**
+     * The source of truth for "dark" must be the AppCompat night-mode decision itself:
+     * a forced Theme (MODE_NIGHT_YES/NO( must beat whatever the activity resources config
+     * currently reports — after a forced Light/Dark switch that resource can still carry the stale
+     * system night bit,derailing the bar icons (white icons on light(. Only Follow System falls
+     * back to the real system night state.
+
+     */
+    private fun isAppDark(): Boolean = when (AppCompatDelegate.getDefaultNightMode()) {
+
+        AppCompatDelegate.MODE_NIGHT_YES -> true
+        AppCompatDelegate.MODE_NIGHT_NO -> false
+        else -> (Resources.getSystem().configuration.uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    }
+
+    private fun reassertSystemBars() {.
         if (window.decorView == null) return
         val controller = WindowCompat.getInsetsController(window, window.decorView)
-        val light = !resources.configuration.isNight()
+        val light = !isAppDark()
+
+        Log.i(TAG, "reassert act=" + this::class.java.simpleName +
+                " nightPref=" + AppCompatDelegate.getDefaultNightMode() +
+                " sysNight=" + Resources.getSystem().configuration.isNight() +
+                " resNight=" + resources.configuration.isNight() +
+                " lightFlag=" + light + " api=" + Build.VERSION.SDK_INT)
+
         controller.setAppearanceLightStatusBars(light)
         controller.setAppearanceLightNavigationBars(light)
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+
+        
+        super.onConfigurationChanged(newConfig)
+        Log.i(TAG, "onConfigChanged act=" + this::class.java.simpleName + " night=" + newConfig.isNight() + " uiMode=" + newConfig.uiMode)
+    }
+
     override fun onResume() {
+
+        
         super.onResume()
         reassertSystemBars()
     }
 
     override fun onSupportNavigateUp(): Boolean {
+
         if (!super.onSupportNavigateUp()) {
             finish()
         }

--- a/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
@@ -77,7 +77,7 @@ abstract class AppActivity : MaterialActivity() {
     private fun isAppDark(): Boolean = when (AppCompatDelegate.getDefaultNightMode()) {
         AppCompatDelegate.MODE_NIGHT_YES -> true
         AppCompatDelegate.MODE_NIGHT_NO -> false
-        else -> (Resources.getSystem().configuration.uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        else -> (Resources.getSystem().configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
     }
  
     private fun reassertSystemBars() {

--- a/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
@@ -21,17 +21,17 @@ abstract class AppActivity : MaterialActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Run enableEdgeToEdge after super.onCreate: SystemBarStyle.auto's dark detection
+        // reads the activity's (resolved( resources (EdgeToEdge passes view.getResources()),
+        // so it must see the AppCompat-resolved night mode — running it before super.onCreate
+        // can capture the stale pre-resolution configuration, leaving the bars on the old
+        // icon appearance after a theme switch until the process restarts.
 
-        // Run enableEdgeToEdge after super.onCreate. The icon appearance comes from the
-        // AppCompat night-mode decision (see isAppDark(,NOT from the activity resources config,
-        // which can lag the rendered theme after a forced Light/Dark switch and leave the bars
-        // on the stale (system( appearance (white icons on light(.
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) { isAppDark() },
             navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) { isAppDark() }
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-
             window.isNavigationBarContrastEnforced = false
         }
     }
@@ -41,7 +41,6 @@ abstract class AppActivity : MaterialActivity() {
     }
 
     override fun onApplyUserThemeResource(theme: Theme, isDecorView: Boolean) {
-
         if (ThemeHelper.isUsingSystemColor()) {
             if (resources.configuration.isNight())
                 theme.applyStyle(R.style.ThemeOverlay_DynamicColors_Dark, true)
@@ -52,69 +51,63 @@ abstract class AppActivity : MaterialActivity() {
         theme.applyStyle(ThemeHelper.getThemeStyleRes(this), true)
 
         // Re-assert the bar icon appearance on the decor pass: enableEdgeToEdge's auto
-        // style computes once when the window is wired up,anda theme-driven recreate can
-        // leave a stale legacy window flag(API≤29( —the bars keep the old icons until the
-        // process restarts. This pass runs after the theme dispatch,so the appearance re-write
-        // makes a Follow-System switch take effect immediately on a theme change.
-
+        // style computes once when the window is wired up, and a theme-driven recreate can
+        // leave a stale legacy window flag (API≤29( — the bars keep the old icons until the
+        // process restarts. This pass runs after the theme dispatch, so the activity's resources
+        // are already resolved — re-write the appearance from them, which makes a Follow-System
+        // switch take effect immediately on a theme change, without needing a process restart.
         if (isDecorView) {
             reassertSystemBars()
         }
     }
 
     /**
-     * Re-assert every decor pass and resume: Follow-System can flip the night mode whilethe
-     * activity is alive (auto-dark / QS tile(,and a stopped activity isn't always recreated for uiMode;
-     * without a re-assertthe bars would keep the old icon appearance whilethe content follows live.
-
+     * Follow-System can flip the night mode while the activity is already alive (auto-dark /
+     * QS tile(, and a stopped activity isn't always recreated for uiMode — the system bar icons
+     * would then stay on the old appearance while the content follows live. Re-derive them from
+     * whatever configuration the content is rendering with, on every resume and the decor pass..
      */
-
     /**
      * The source of truth for "dark" must be the AppCompat night-mode decision itself:
      * a forced Theme (MODE_NIGHT_YES/NO( must beat whatever the activity resources config
-     * currently reports — after a forced Light/Dark switch that resource can still carry the stale
-     * system night bit,derailing the bar icons (white icons on light(. Only Follow System falls
-     * back to the real system night state.
-
+     * currently reports. After a forced Light/Dark switch that resource can still carry the stale
+     * system night bit,which would leave the bar icons wrong (white icons on light(.
+     * Only Follow System falls back to the real system night state.
      */
     private fun isAppDark(): Boolean = when (AppCompatDelegate.getDefaultNightMode()) {
-
         AppCompatDelegate.MODE_NIGHT_YES -> true
         AppCompatDelegate.MODE_NIGHT_NO -> false
         else -> (Resources.getSystem().configuration.uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
     }
-
-    private fun reassertSystemBars() {.
+ 
+    private fun reassertSystemBars() {
         if (window.decorView == null) return
         val controller = WindowCompat.getInsetsController(window, window.decorView)
         val light = !isAppDark()
-
+ 
         Log.i(TAG, "reassert act=" + this::class.java.simpleName +
                 " nightPref=" + AppCompatDelegate.getDefaultNightMode() +
                 " sysNight=" + Resources.getSystem().configuration.isNight() +
                 " resNight=" + resources.configuration.isNight() +
                 " lightFlag=" + light + " api=" + Build.VERSION.SDK_INT)
-
+ 
+        controller.setAppearanceLightStatusBars(light)
+        controller.setAppearanceLightNavigationBars(light)
         controller.setAppearanceLightStatusBars(light)
         controller.setAppearanceLightNavigationBars(light)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
-
-        
         super.onConfigurationChanged(newConfig)
         Log.i(TAG, "onConfigChanged act=" + this::class.java.simpleName + " night=" + newConfig.isNight() + " uiMode=" + newConfig.uiMode)
     }
-
+ 
     override fun onResume() {
-
-        
         super.onResume()
         reassertSystemBars()
     }
 
     override fun onSupportNavigateUp(): Boolean {
-
         if (!super.onSupportNavigateUp()) {
             finish()
         }


### PR DESCRIPTION
## What

Follow-System can flip the night mode while the activity is already alive (auto-dark at
sunset, Quick Settings tile(. A stopped activity is not always recreated for a uiMode
change, so the system bar icons kept the old appearance while the content followed live.

This re-derives the bar icon appearance from the current configuration in `onResume()`,
in addition to the existing decor-theme pass — so the bars always match whatever the content
is rendering with.

## Test

Tester reported the status bar bug still occurs with Follow System enabled. Repro paths
that should now be covered:

1. Settings → Appearance → switch theme Light ↔ Follow System — bars match immediately.

2. Open Shevery → background it (Home( → toggle Dark mode in Quick Settings → return —
3. both bars and content follow the system.."( 2. auto-dark while backgrounded → same as #2.