### PR TITLE
fix(ui): unify night-mode detector for bars and content

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ShizukuApplication.kt
@@ -32,7 +32,16 @@ class ShizukuApplication : Application() {
     private fun init(context: Context?) {
         ShizukuSettings.initialize(context)
         LocaleDelegate.defaultLocale = ShizukuSettings.getLocale()
-        AppCompatDelegate.setDefaultNightMode(ShizukuSettings.getNightMode())
+        // Value 3 is a legacy "follow system" constant once shipped in
+        // night_mode_value; AppCompat only understands -1/1/2. Normalize once
+        // at startup so devices that stored 3 get real FOLLOW_SYSTEM.
+        val nightMode = when (ShizukuSettings.getNightMode()) {
+            AppCompatDelegate.MODE_NIGHT_YES,
+            AppCompatDelegate.MODE_NIGHT_NO,
+            AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM -> ShizukuSettings.getNightMode()
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
+        AppCompatDelegate.setDefaultNightMode(nightMode)
     }
 
     override fun onCreate() {

--- a/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/app/AppActivity.kt
@@ -37,7 +37,12 @@ abstract class AppActivity : MaterialActivity() {
     }
 
     override fun computeUserThemeKey(): String {
-        return ThemeHelper.getTheme(this) + ThemeHelper.isUsingSystemColor()
+        // Include the resolved night state: rikka keys themed state by this string,
+        // and a Light/Dark/Follow switch that leaves the key unchanged can keep
+        // stale theme attributes (e.g. the Light theme's opaque bar color) alive
+        // across recreate() -- cleared only by process death, i.e. "restart fixes it".
+        val night = if (isAppDark()) "dark" else "light"
+        return ThemeHelper.getTheme(this) + ThemeHelper.isUsingSystemColor() + night
     }
 
     override fun onApplyUserThemeResource(theme: Theme, isDecorView: Boolean) {
@@ -68,29 +73,30 @@ abstract class AppActivity : MaterialActivity() {
      * whatever configuration the content is rendering with, on every resume and the decor pass..
      */
     /**
-     * The source of truth for "dark" must be the AppCompat night-mode decision itself:
-     * a forced Theme (MODE_NIGHT_YES/NO( must beat whatever the activity resources config
-     * currently reports. After a forced Light/Dark switch that resource can still carry the stale
-     * system night bit,which would leave the bar icons wrong (white icons on light(.
-     * Only Follow System falls back to the real system night state.
+     * Single source of truth lives in ThemeHelper.resolveAppDark(), shared with
+     * the Compose content (ShizukuExpressiveTheme): explicit Light/Dark wins,
+     * Follow System reads the system night state the same way in both places.
+     * Two different detectors here is exactly how the bars ended up disagreeing
+     * with the content after a Light/Dark to Follow System switch.
      */
-    private fun isAppDark(): Boolean = when (AppCompatDelegate.getDefaultNightMode()) {
-        AppCompatDelegate.MODE_NIGHT_YES -> true
-        AppCompatDelegate.MODE_NIGHT_NO -> false
-        else -> (Resources.getSystem().configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
-    }
- 
+    private fun isAppDark(): Boolean = ThemeHelper.resolveAppDark(this)
+
     private fun reassertSystemBars() {
         if (window.decorView == null) return
         val controller = WindowCompat.getInsetsController(window, window.decorView)
         val light = !isAppDark()
- 
+
         Log.i(TAG, "reassert act=" + this::class.java.simpleName +
                 " nightPref=" + AppCompatDelegate.getDefaultNightMode() +
                 " sysNight=" + Resources.getSystem().configuration.isNight() +
                 " resNight=" + resources.configuration.isNight() +
                 " lightFlag=" + light + " api=" + Build.VERSION.SDK_INT)
- 
+
+        // Re-assert the colors too, not just the icon flags: the activity theme
+        // is always Theme.Light, whose opaque statusBarColor resurfaces on any
+        // path that re-applies the theme without running enableEdgeToEdge again.
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
         controller.setAppearanceLightStatusBars(light)
         controller.setAppearanceLightNavigationBars(light)
         controller.setAppearanceLightStatusBars(light)

--- a/manager/src/main/java/moe/shizuku/manager/app/ThemeHelper.java
+++ b/manager/src/main/java/moe/shizuku/manager/app/ThemeHelper.java
@@ -1,9 +1,13 @@
 package moe.shizuku.manager.app;
 
+import android.app.UiModeManager;
 import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
 
 import androidx.annotation.StyleRes;
+import androidx.appcompat.app.AppCompatDelegate;
 
 import moe.shizuku.manager.R;
 import moe.shizuku.manager.ShizukuSettings;
@@ -45,5 +49,26 @@ public class ThemeHelper {
             default:
                 return R.style.ThemeOverlay;
         }
+    }
+
+    /**
+     * Single source of truth for "is the app dark right now", shared by the
+     * activity system bars (AppActivity) and the Compose content
+     * (ShizukuExpressiveTheme). An explicit Light/Dark choice always wins;
+     * Follow System reads the system night state the same way in both places,
+     * so the bars and the content can never disagree after a theme switch.
+     */
+    public static boolean resolveAppDark(Context context) {
+        int nightMode = ShizukuSettings.getNightMode();
+        if (nightMode == AppCompatDelegate.MODE_NIGHT_YES) return true;
+        if (nightMode == AppCompatDelegate.MODE_NIGHT_NO) return false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            UiModeManager uiModeManager = context.getSystemService(UiModeManager.class);
+            if (uiModeManager != null) {
+                return uiModeManager.getNightMode() == UiModeManager.MODE_NIGHT_YES;
+            }
+        }
+        return (Resources.getSystem().getConfiguration().uiMode
+                & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/app/ThemeHelper.java
+++ b/manager/src/main/java/moe/shizuku/manager/app/ThemeHelper.java
@@ -1,9 +1,7 @@
 package moe.shizuku.manager.app;
 
-import android.app.UiModeManager;
 import android.content.Context;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Build;
 
 import androidx.annotation.StyleRes;
@@ -55,20 +53,23 @@ public class ThemeHelper {
      * Single source of truth for "is the app dark right now", shared by the
      * activity system bars (AppActivity) and the Compose content
      * (ShizukuExpressiveTheme). An explicit Light/Dark choice always wins;
-     * Follow System reads the system night state the same way in both places,
-     * so the bars and the content can never disagree after a theme switch.
+     * Follow System reads the caller context's *resolved* configuration --
+     * i.e. what AppCompat actually applied -- so bars and content agree by
+     * construction.
+     *
+     * Deliberately NOT UiModeManager and NOT Resources.getSystem(): on phones
+     * UiModeManager.getNightMode() reports car-dock state (almost always NO),
+     * and the system config is the input to AppCompat, not its output.
+     * Value 3 (legacy "follow" constant once shipped in night_mode_value) is
+     * normalized to FOLLOW_SYSTEM so devices that stored it keep working.
      */
     public static boolean resolveAppDark(Context context) {
         int nightMode = ShizukuSettings.getNightMode();
         if (nightMode == AppCompatDelegate.MODE_NIGHT_YES) return true;
         if (nightMode == AppCompatDelegate.MODE_NIGHT_NO) return false;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            UiModeManager uiModeManager = context.getSystemService(UiModeManager.class);
-            if (uiModeManager != null) {
-                return uiModeManager.getNightMode() == UiModeManager.MODE_NIGHT_YES;
-            }
-        }
-        return (Resources.getSystem().getConfiguration().uiMode
-                & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        if (nightMode == 3) nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+        Configuration config = context.getResources().getConfiguration();
+        return (config.uiMode & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_YES;
     }
 }

--- a/manager/src/main/java/moe/shizuku/manager/ui/compose/ShizukuExpressive.kt
+++ b/manager/src/main/java/moe/shizuku/manager/ui/compose/ShizukuExpressive.kt
@@ -6,10 +6,7 @@
 
 package moe.shizuku.manager.ui.compose
 
-import android.app.UiModeManager
-import android.content.res.Configuration
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -102,7 +99,6 @@ import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import moe.shizuku.manager.ShizukuSettings
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
@@ -299,23 +295,9 @@ fun ExpressiveFloatingNavigationBar(
 @Composable
 fun ShizukuExpressiveTheme(content: @Composable () -> Unit) {
     val context = LocalContext.current
-    // Resolve dark from the user's night-mode setting, not the raw system flag:
-    // isSystemInDarkTheme() ignores AppCompatDelegate overrides, so explicit
-    // Light/Dark choices (and follow-system on some ROMs) never reached Compose.
-    val systemDark = remember {
-        val uiModeManager = context.getSystemService(UiModeManager::class.java)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && uiModeManager != null) {
-            uiModeManager.nightMode == UiModeManager.MODE_NIGHT_YES
-        } else {
-            (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-                Configuration.UI_MODE_NIGHT_YES
-        }
-    }
-    val dark = when (ShizukuSettings.getNightMode()) {
-        AppCompatDelegate.MODE_NIGHT_YES -> true
-        AppCompatDelegate.MODE_NIGHT_NO -> false
-        else -> systemDark
-    }
+    // Same detector as the activity system bars (ThemeHelper.resolveAppDark):
+    // one source of truth, so bars and content can never disagree after a switch.
+    val dark = remember { ThemeHelper.resolveAppDark(context) }
     val baseScheme = when {
         ThemeHelper.isUsingSystemColor() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && dark ->
             dynamicDarkColorScheme(context)

--- a/manager/src/main/res/values/arrays.xml
+++ b/manager/src/main/res/values/arrays.xml
@@ -10,7 +10,7 @@
     <integer-array name="night_mode_value">
         <item>1</item>
         <item>2</item>
-        <item>3</item>
+        <item>-1</item>
     </integer-array>
 
 </resources>


### PR DESCRIPTION
Tester issue: Light/Dark to Follow System switch leaves status/nav bars white until Shevery restarts.

Root cause, verified by reading (no local build per project rule):
- Bars derived dark from Resources.getSystem() (AppActivity.isAppDark), content from UiModeManager (ShizukuExpressiveTheme). Two detectors, one switch: when they disagree the bars mismatch the content.
- Rikka keys themed state by computeUserThemeKey(), which had no night component, so stale theme attributes (Theme.Light's opaque statusBarColor) could survive recreate() and only clear on process death.
- Re-assert path rewrote icon flags but never the bar colors.

This change:
1. New ThemeHelper.resolveAppDark(): explicit Light/Dark wins, Follow System reads UiModeManager first, Resources fallback. Used by both AppActivity and ShizukuExpressiveTheme. Bars and content cannot disagree by construction.
2. computeUserThemeKey() now includes the resolved night state, busting stale rikka themed state across switches.
3. reassertSystemBars() re-asserts transparent bar colors alongside the icon flags.
4. Drops the now-duplicated detector + unused imports in ShizukuExpressive.kt.

Test: fresh build off this branch, system theme set, then cycle Appearance Light -> Follow System and Dark -> Follow System. Expect bars to match content immediately, no restart. SheverySB logcat lines show the resolved values.