### PR TITLE
fix(stub): bump versionCode to suppress Play Store update prompts

### DIFF
--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -6,7 +6,7 @@ android {
     namespace 'moe.shizuku.privileged.api'
     defaultConfig {
         applicationId "moe.shizuku.privileged.api"
-        versionCode 600
+        versionCode 2000000000
         versionName "13.9.0"
     }
     buildFeatures {


### PR DESCRIPTION
Closes #118

### Summary
The legacy stub apk (`moe.shizuku.privileged.api`) had `versionCode 600`. Upstream Shizuku on Play Store is past 1030+, causing Play Store to treat the stub as outdated and constantly offer updates (which fail due to signature mismatch).

### Changes
- Bump `versionCode` in `:stub/build.gradle` from `600` to `2000000000`.

Play Store checks `local_version < store_version`; setting a high versionCode stops Play Store from showing update prompts for the stub. `StubManager` installs via `pm install -r -d -t` (downgrade allowed), so it installs without conflicts.