### PR TITLE
fix(adb): harden wireless ADB startup, TCP 5555 switching, and watchdog recovery

### DIFF
--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbClient.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbClient.kt
@@ -19,6 +19,7 @@ import rikka.core.util.BuildUtils
 import java.io.Closeable
 import java.io.DataInputStream
 import java.io.DataOutputStream
+import java.net.InetSocketAddress
 import java.net.Socket
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -42,8 +43,10 @@ class AdbClient(private val host: String, private val port: Int, private val key
     private val outputStream get() = if (useTls) tlsOutputStream else plainOutputStream
 
     fun connect() {
-        socket = Socket(host, port)
+        socket = Socket()
         socket.tcpNoDelay = true
+        socket.soTimeout = 15_000
+        socket.connect(InetSocketAddress(host, port), 5_000)
         plainInputStream = DataInputStream(socket.getInputStream())
         plainOutputStream = DataOutputStream(socket.getOutputStream())
 
@@ -58,6 +61,7 @@ class AdbClient(private val host: String, private val port: Int, private val key
 
             val sslContext = key.sslContext
             tlsSocket = sslContext.socketFactory.createSocket(socket, host, port, true) as SSLSocket
+            tlsSocket.soTimeout = 15_000
             tlsSocket.startHandshake()
             Log.d(TAG, "Handshake succeeded.")
 

--- a/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
+++ b/manager/src/main/java/moe/shizuku/manager/adb/AdbStarter.kt
@@ -9,8 +9,7 @@ import kotlinx.coroutines.delay
 import moe.shizuku.manager.ShizukuSettings
 import moe.shizuku.manager.starter.Starter
 import moe.shizuku.manager.utils.EnvironmentUtils
-import java.io.EOFException
-import java.net.SocketException
+import java.io.IOException
 
 object AdbStarter {
 
@@ -27,6 +26,7 @@ object AdbStarter {
         val key = AdbKey(PreferenceAdbKeyStore(ShizukuSettings.getPreferences()), "shizuku")
         val tcpMode = ShizukuSettings.isTcpMode()
         val targetPort = if (tcpMode) TCP_MODE_PORT else port
+        var startedSuccessfully = false
 
         try {
             val isTargetAlreadyLive = EnvironmentUtils.isAdbPortLive(targetPort)
@@ -41,11 +41,12 @@ object AdbStarter {
                 ShizukuSettings.setLastAdbPort(targetPort)
                 client.shellCommand(Starter.internalCommand, listener)
             }
+            startedSuccessfully = true
         } finally {
             // Only touch wireless debugging when this starter put the device
-            // in TCP mode; unconditional disable would kill USB-started
-            // sessions and override the user's system setting.
-            if (tcpMode) {
+            // in TCP mode and successfully launched the service; unconditional
+            // disable would break automatic retry and recovery on failure.
+            if (tcpMode && startedSuccessfully) {
                 disableWirelessDebugging(context)
             }
         }
@@ -66,10 +67,8 @@ object AdbStarter {
             client.connect()
             try {
                 client.command("tcpip:$targetPort")
-            } catch (e: EOFException) {
-                // Expected: adbd restarts when switching from wireless debugging to TCP mode.
-            } catch (e: SocketException) {
-                // Expected: adbd restarts when switching from wireless debugging to TCP mode.
+            } catch (e: IOException) {
+                // Expected: adbd restarts (dropping TCP/TLS socket) when switching to TCP mode.
             }
         }
     }

--- a/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
+++ b/manager/src/main/java/moe/shizuku/manager/home/HomeActivity.kt
@@ -78,6 +78,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -424,10 +425,8 @@ abstract class HomeActivity : AppActivity() {
                                                 Toast.makeText(this@HomeActivity, R.string.settings_tcp_mode, Toast.LENGTH_SHORT).show()
                                             }
                                         } else {
-                                            val port = EnvironmentUtils.getLiveAdbTcpPort().takeIf { it > 0 }
-                                                ?: EnvironmentUtils.getAdbTcpPort().takeIf { it > 0 }
-                                                ?: ShizukuSettings.getLastAdbPort().takeIf { it > 0 }
-                                            if (port != null && port > 0) {
+                                            val port = EnvironmentUtils.getActiveAdbPort().takeIf { it > 0 }
+                                            if (port != null) {
                                                 withContext(Dispatchers.Main) {
                                                     moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@HomeActivity)
                                                     startActivity(
@@ -437,6 +436,10 @@ abstract class HomeActivity : AppActivity() {
                                                             putExtra(StarterActivity.EXTRA_PORT, port)
                                                         }
                                                     )
+                                                }
+                                            } else {
+                                                withContext(Dispatchers.Main) {
+                                                    Toast.makeText(this@HomeActivity, R.string.dialog_wireless_adb_not_enabled, Toast.LENGTH_SHORT).show()
                                                 }
                                             }
                                         }
@@ -699,22 +702,22 @@ abstract class HomeActivity : AppActivity() {
             return
         }
 
-        val livePort = EnvironmentUtils.getLiveAdbTcpPort().takeIf { it > 0 }
-            ?: EnvironmentUtils.getAdbTcpPort().takeIf { it > 0 && EnvironmentUtils.isAdbPortLive(it) }
-            ?: if (EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT)) AdbStarter.TCP_MODE_PORT else null
-
-        if (livePort != null) {
-            startActivity(
-                Intent(this, StarterActivity::class.java).apply {
-                    putExtra(StarterActivity.EXTRA_IS_ROOT, false)
-                    putExtra(StarterActivity.EXTRA_HOST, "127.0.0.1")
-                    putExtra(StarterActivity.EXTRA_PORT, livePort)
+        lifecycleScope.launch(Dispatchers.IO) {
+            val livePort = EnvironmentUtils.getActiveAdbPort().takeIf { it > 0 }
+            withContext(Dispatchers.Main) {
+                if (livePort != null) {
+                    startActivity(
+                        Intent(this@HomeActivity, StarterActivity::class.java).apply {
+                            putExtra(StarterActivity.EXTRA_IS_ROOT, false)
+                            putExtra(StarterActivity.EXTRA_HOST, "127.0.0.1")
+                            putExtra(StarterActivity.EXTRA_PORT, livePort)
+                        }
+                    )
+                } else {
+                    onWadbNotEnabled()
                 }
-            )
-            return
+            }
         }
-
-        onWadbNotEnabled()
     }
 
     private fun pairWirelessAdb(onShowPairDialog: () -> Unit) {
@@ -786,154 +789,6 @@ abstract class HomeActivity : AppActivity() {
         )
     }
 
-    private fun bindTcp5555() {
-        moe.shizuku.manager.service.WatchdogManager.clearUserStopRequest(this@HomeActivity)
-        lifecycleScope.launch(Dispatchers.IO) {
-            var success = false
-            var failureReason = getString(R.string.settings_tcp_5555_bind_failed_generic)
-
-            fun recordBindFailure(route: String, reason: String, throwable: Throwable? = null) {
-                val message = "$route: $reason"
-                failureReason = message
-                android.util.Log.d("Shevery", "Failed to bind TCP 5555 via $message", throwable)
-            }
-
-            // 0. Prefer the actual ADB protocol path (adb tcpip 5555).
-            // Running setprop/stop/start through the Shevery shell process is not equivalent to
-            // adb tcpip and can fail with exit code 1 even when the service is active.
-            if (EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT)) {
-                success = true
-            } else {
-                val activePort = EnvironmentUtils.getLiveAdbTcpPort()
-                    .takeIf { it > 0 && it != AdbStarter.TCP_MODE_PORT }
-                    ?: EnvironmentUtils.getAdbTcpPort().takeIf { it > 0 && it != AdbStarter.TCP_MODE_PORT }
-
-                if (activePort != null) {
-                    try {
-                        AdbStarter.switchToTcpMode(currentPort = activePort)
-                        success = waitForAdbTcpPort(AdbStarter.TCP_MODE_PORT)
-                        if (!success) {
-                            recordBindFailure("ADB", "tcpip command finished but port 5555 did not become live")
-                        }
-                    } catch (e: Exception) {
-                        recordBindFailure("ADB", e.message ?: e.javaClass.simpleName, e)
-                    }
-                } else {
-                    recordBindFailure("ADB", "no active local ADB port was found")
-                }
-            }
-
-            // 1. Try via Dhizuku if enabled
-            if (ModuleSettings.isDhizukuEnabled()) {
-                try {
-                    val initResult = com.rosan.dhizuku.api.Dhizuku.init(applicationContext)
-                    if (initResult && com.rosan.dhizuku.api.Dhizuku.isPermissionGranted()) {
-                        val userServiceArgs = com.rosan.dhizuku.api.DhizukuUserServiceArgs(
-                            android.content.ComponentName(applicationContext, moe.shizuku.manager.dhizuku.DhizukuService::class.java)
-                        )
-                        var connection: android.content.ServiceConnection? = null
-                        val serviceResult = withTimeoutOrNull(5000) {
-                            suspendCancellableCoroutine<android.os.IBinder?> { cont ->
-                                val conn = object : android.content.ServiceConnection {
-                                    override fun onServiceConnected(name: android.content.ComponentName?, service: android.os.IBinder?) {
-                                        if (cont.isActive) cont.resumeWith(Result.success(service))
-                                    }
-                                    override fun onServiceDisconnected(name: android.content.ComponentName?) {}
-                                }
-                                connection = conn
-                                val bound = com.rosan.dhizuku.api.Dhizuku.bindUserService(userServiceArgs, conn)
-                                if (!bound && cont.isActive) {
-                                    cont.resumeWith(Result.success(null))
-                                }
-                            }
-                        }
-                        if (serviceResult != null) {
-                            val dhizukuService = moe.shizuku.manager.dhizuku.IDhizukuService.Stub.asInterface(serviceResult)
-                            success = dhizukuService.bindAdbTcp(AdbStarter.TCP_MODE_PORT) && waitForAdbTcpPort(AdbStarter.TCP_MODE_PORT)
-                            if (!success) {
-                                recordBindFailure("Dhizuku", "command finished but port 5555 did not become live")
-                            }
-                            connection?.let {
-                                try { com.rosan.dhizuku.api.Dhizuku.unbindUserService(it) } catch (_: Exception) {}
-                            }
-                        } else {
-                            recordBindFailure("Dhizuku", "service binding failed or timed out")
-                        }
-                    } else if (!initResult) {
-                        recordBindFailure("Dhizuku", "initialization failed")
-                    } else {
-                        recordBindFailure("Dhizuku", "permission is not granted")
-                    }
-                } catch (e: Exception) {
-                    recordBindFailure("Dhizuku", e.message ?: e.javaClass.simpleName, e)
-                }
-            }
-
-            // 2. Try via Root if not success
-            if (!success && EnvironmentUtils.isRooted()) {
-                try {
-                    val result = com.topjohnwu.superuser.Shell.cmd(ADB_TCP_BIND_COMMAND).exec()
-                    success = result.isSuccess && waitForAdbTcpPort(AdbStarter.TCP_MODE_PORT)
-                    if (!success) {
-                        recordBindFailure(
-                            "root",
-                            "command exit code ${result.code}, port 5555 live: ${EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT)}"
-                        )
-                    }
-                } catch (e: Exception) {
-                    recordBindFailure("root", e.message ?: e.javaClass.simpleName, e)
-                }
-            } else if (!success) {
-                recordBindFailure("root", "root shell is unavailable")
-            }
-
-            // 3. Try via Shizuku shell if running
-            if (!success && Shizuku.pingBinder()) {
-                try {
-                    val binder = Shizuku.getBinder()
-                    if (binder != null) {
-                        val service = moe.shizuku.server.IShizukuService.Stub.asInterface(binder)
-                        val process = service.newProcess(arrayOf("sh", "-c", ADB_TCP_BIND_COMMAND), null, null)
-                        val exitCode = process.waitFor()
-                        success = exitCode == 0 && waitForAdbTcpPort(AdbStarter.TCP_MODE_PORT)
-                        if (!success) {
-                            recordBindFailure(
-                                "Shevery",
-                                "command exit code $exitCode, port 5555 live: ${EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT)}"
-                            )
-                        }
-                    } else {
-                        recordBindFailure("Shevery", "binder was null")
-                    }
-                } catch (e: Exception) {
-                    recordBindFailure("Shevery", e.message ?: e.javaClass.simpleName, e)
-                }
-            } else if (!success) {
-                recordBindFailure("Shevery", "binder is not active")
-            }
-
-            withContext(Dispatchers.Main) {
-                if (success) {
-                    Toast.makeText(this@HomeActivity, R.string.settings_tcp_5555_bind_success, Toast.LENGTH_SHORT).show()
-                    startActivity(
-                        Intent(this@HomeActivity, StarterActivity::class.java).apply {
-                            putExtra(StarterActivity.EXTRA_IS_ROOT, false)
-                            putExtra(StarterActivity.EXTRA_HOST, "127.0.0.1")
-                            putExtra(StarterActivity.EXTRA_PORT, AdbStarter.TCP_MODE_PORT)
-                        }
-                    )
-                } else {
-                    Toast.makeText(
-                        this@HomeActivity,
-                        getString(R.string.settings_tcp_5555_bind_failed, failureReason),
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
-            }
-        }
-    }
-
-
     private fun isPermissionDefined(permission: String): Boolean {
         return try {
             packageManager.getPermissionInfo(permission, 0)
@@ -943,16 +798,7 @@ abstract class HomeActivity : AppActivity() {
         }
     }
 
-    private suspend fun waitForAdbTcpPort(port: Int): Boolean {
-        repeat(10) {
-            if (EnvironmentUtils.isAdbPortLive(port)) return true
-            delay(500)
-        }
-        return false
-    }
-
     companion object {
-        private const val ADB_TCP_BIND_COMMAND = "setprop service.adb.tcp.port 5555; setprop ctl.restart adbd || (stop adbd; start adbd)"
         private const val SDK_ANDROID_13 = 33
         private const val SDK_ANDROID_17 = 37
         private const val PERMISSION_ACCESS_LOCAL_NETWORK = "android.permission.ACCESS_LOCAL_NETWORK"
@@ -1014,10 +860,19 @@ private fun HomeScreen(
     val grantedCount = grantedResource?.data ?: 0
     val running = serverState == ShizukuStateMachine.State.RUNNING || status.isRunning
     val adbPermission = status.permission
-    val canUseWirelessAdb = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-        || EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT)
-        || EnvironmentUtils.getLiveAdbTcpPort() > 0
-        || ShizukuSettings.isTcpMode()
+    val canUseWirelessAdb by produceState(
+        initialValue = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || ShizukuSettings.isTcpMode(),
+        key1 = status.isRunning
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || ShizukuSettings.isTcpMode()) {
+            value = true
+        } else {
+            value = withContext(Dispatchers.IO) {
+                EnvironmentUtils.isAdbPortLive(AdbStarter.TCP_MODE_PORT) ||
+                    EnvironmentUtils.getLiveAdbTcpPort() > 0
+            }
+        }
+    }
     val diagnostics = remember(status, grantedCount, localNetworkPermissionState) {
         buildDiagnostics(context, status, grantedCount, localNetworkPermissionState)
     }

--- a/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/BootCompleteReceiver.kt
@@ -37,34 +37,42 @@ class BootCompleteReceiver : BroadcastReceiver() {
         // Schedule app auto-update check (cheap, no-op if already scheduled)
         moe.shizuku.manager.module.update.SheveryAutoUpdateWorker.maybeSchedule(context)
 
-        if (ShizukuSettings.getStartOnBootAdb()
-            && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) {
-                moe.shizuku.manager.service.StartupNotificationManager.showFailed(
-                    context,
-                    context.getString(moe.shizuku.manager.R.string.notification_startup_no_permission)
-                )
-                return
-            }
-            // On API 33+ (Android 13+), Wi-Fi/mDNS discovery requires NEARBY_WIFI_DEVICES
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-                && context.checkSelfPermission(NEARBY_WIFI_DEVICES) != PackageManager.PERMISSION_GRANTED) {
-                moe.shizuku.manager.service.StartupNotificationManager.showFailed(
-                    context,
-                    context.getString(moe.shizuku.manager.R.string.notification_startup_no_permission)
-                )
-                return
-            }
-            // On API 36+ (Android 16+), local network access requires ACCESS_LOCAL_NETWORK
-            val ACCESS_LOCAL_NETWORK_PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
-            if (Build.VERSION.SDK_INT >= 36
-                && context.checkSelfPermission(ACCESS_LOCAL_NETWORK_PERMISSION)
-                        != PackageManager.PERMISSION_GRANTED) {
-                moe.shizuku.manager.service.StartupNotificationManager.showFailed(
-                    context,
-                    context.getString(moe.shizuku.manager.R.string.notification_startup_no_permission)
-                )
-                return
+        val isAdbCandidate = ShizukuSettings.getStartOnBootAdb() && (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R ||
+            EnvironmentUtils.getAdbTcpPort() > 0 ||
+            ShizukuSettings.isTcpMode() ||
+            EnvironmentUtils.isTV(context)
+        )
+
+        if (isAdbCandidate) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                if (context.checkSelfPermission(WRITE_SECURE_SETTINGS) != PackageManager.PERMISSION_GRANTED) {
+                    moe.shizuku.manager.service.StartupNotificationManager.showFailed(
+                        context,
+                        context.getString(moe.shizuku.manager.R.string.notification_startup_no_permission)
+                    )
+                    return
+                }
+                // On API 33+ (Android 13+), Wi-Fi/mDNS discovery requires NEARBY_WIFI_DEVICES
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                    && context.checkSelfPermission(NEARBY_WIFI_DEVICES) != PackageManager.PERMISSION_GRANTED) {
+                    moe.shizuku.manager.service.StartupNotificationManager.showFailed(
+                        context,
+                        context.getString(moe.shizuku.manager.R.string.notification_startup_no_permission)
+                    )
+                    return
+                }
+                // On API 36+ (Android 16+), local network access requires ACCESS_LOCAL_NETWORK
+                val ACCESS_LOCAL_NETWORK_PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
+                if (Build.VERSION.SDK_INT >= 36
+                    && context.checkSelfPermission(ACCESS_LOCAL_NETWORK_PERMISSION)
+                            != PackageManager.PERMISSION_GRANTED) {
+                    moe.shizuku.manager.service.StartupNotificationManager.showFailed(
+                        context,
+                        context.getString(moe.shizuku.manager.R.string.notification_startup_no_permission)
+                    )
+                    return
+                }
             }
             val tcpPort = EnvironmentUtils.getAdbTcpPort()
             if (tcpPort > 0 && (EnvironmentUtils.isTV(context) || ShizukuSettings.isTcpMode())) {
@@ -150,20 +158,6 @@ class BootCompleteReceiver : BroadcastReceiver() {
             return
         }
         // Timeout handles the case where user never unlocks
-    }
-
-    private fun hasLocalNetworkPermission(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-            && context.checkSelfPermission(NEARBY_WIFI_DEVICES) != PackageManager.PERMISSION_GRANTED) {
-            return false
-        }
-        val ACCESS_LOCAL_NETWORK_PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK"
-        if (Build.VERSION.SDK_INT >= 36
-            && context.checkSelfPermission(ACCESS_LOCAL_NETWORK_PERMISSION)
-                    != PackageManager.PERMISSION_GRANTED) {
-            return false
-        }
-        return true
     }
 
     private fun rootStart(context: Context) {

--- a/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
+++ b/manager/src/main/java/moe/shizuku/manager/receiver/SheveryControlReceiver.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import moe.shizuku.manager.AppConstants
+import moe.shizuku.manager.ShizukuSettings
+import moe.shizuku.manager.ShizukuSettings.LaunchMethod
 import moe.shizuku.manager.ktx.logw
 import moe.shizuku.manager.service.SheveryNotificationManager
 import moe.shizuku.manager.service.WatchdogManager
@@ -22,22 +24,15 @@ class SheveryControlReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             ACTION_START_SERVER -> {
-                WatchdogManager.clearUserStopRequest(context.applicationContext)
-                // Re-enqueue the constrained worker too: the error
-                // notification's tap previously only attempted an immediate
-                // mDNS start (which fails on cellular) and left the boot work
-                // in FAILED state, so returning to Wi-Fi never resumed it.
-                // The worker carries the UNMETERED constraint and now retries
-                // transient failures instead of terminally failing.
-                AdbStartWorker.enqueue(context.applicationContext)
-                // Refresh the worker banner to match reality: REPLACE force-
-                // starts a fresh attempt, so the state flips immediately instead
-                // of looking dead or leaving a stale "awaiting Wi-Fi" banner.
                 val appCtx = context.applicationContext
-                ShizukuReceiverStarter.updateNotification(appCtx,
-                    AdbStartWorker.bannerStateFor(appCtx)
-                )
-                WatchdogManager.attemptRestart(context.applicationContext)
+                WatchdogManager.clearUserStopRequest(appCtx)
+                if (ShizukuSettings.getLastLaunchMode() == LaunchMethod.ADB) {
+                    AdbStartWorker.enqueue(appCtx)
+                    ShizukuReceiverStarter.updateNotification(appCtx,
+                        AdbStartWorker.bannerStateFor(appCtx)
+                    )
+                }
+                WatchdogManager.attemptRestart(appCtx)
             }
             ACTION_STOP_SERVER -> {
                 val pendingResult = goAsync()

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogManager.kt
@@ -12,6 +12,7 @@ import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import moe.shizuku.manager.MainActivity
@@ -40,7 +41,7 @@ object WatchdogManager {
     private const val CHANNEL_ID = "service_watchdog"
     private const val DEATH_CHANNEL_ID = "service_watchdog_death"
     private const val NOTIFICATION_ID = 1001
-    private const val EXPECTED_DEATH_WINDOW_MS = 10_000L
+    private const val EXPECTED_DEATH_WINDOW_MS = 30_000L
     private const val DHIZUKU_BIND_TIMEOUT_MS = 10_000L
     private const val KEY_USER_STOP_REQUESTED = "watchdog_user_stop_requested"
 
@@ -83,6 +84,7 @@ object WatchdogManager {
 
         Shizuku.addBinderReceivedListenerSticky {
             expectingDeath = false
+            clearUserStopRequest(appContext)
         }
 
         Shizuku.addBinderDeadListener {
@@ -95,10 +97,11 @@ object WatchdogManager {
     }
 
     /**
-     * True while the expected-death suppression window (10s( is still open. A stale
-     *  flag must not block the watchdog poll loop forever when no binder transition fires.
+     * True while the expected-death suppression window is still open or starter is active.
+     * A stale flag must not block the watchdog poll loop forever when no binder transition fires.
      */
     fun isExpectingDeathActive(): Boolean {
+        if (isStarterActive) return true
         if (!expectingDeath) return false
         val deadline = expectedDeathDeadlineMillis
         if (deadline == 0L) return true
@@ -306,7 +309,7 @@ object WatchdogManager {
         return ShizukuStateMachine.awaitStopped(timeoutMs)
     }
 
-    private fun forceStopServerProcess(): String? {
+    private suspend fun forceStopServerProcess(): String? {
         return try {
             if (!Shizuku.pingBinder()) return null
             val binder = Shizuku.getBinder() ?: return "binder was null"
@@ -316,7 +319,12 @@ object WatchdogManager {
                 null,
                 null
             )
-            val exitCode = process.waitFor()
+            val exitCode = withTimeoutOrNull(3_000L) {
+                runInterruptible { process.waitFor() }
+            } ?: run {
+                process.destroy()
+                -1
+            }
             if (exitCode == 0) null else "fallback kill exit code $exitCode"
         } catch (e: Throwable) {
             logd("Failed to force-stop Shevery service process: ${e.message}")

--- a/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
+++ b/manager/src/main/java/moe/shizuku/manager/service/WatchdogService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.*
 import moe.shizuku.manager.MainActivity
 import moe.shizuku.manager.R
 import moe.shizuku.manager.ktx.logd
+import moe.shizuku.manager.utils.ShizukuStateMachine
 
 class WatchdogService : Service() {
 
@@ -89,7 +90,7 @@ class WatchdogService : Service() {
                     logd("Watchdog: Binder check threw exception: ${e.message}")
                 }
 
-                if (!healthy && !WatchdogManager.isExpectingDeathActive() && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService()) {
+                if (!healthy && !WatchdogManager.isExpectingDeathActive() && !WatchdogManager.isUserStopRequested() && WatchdogManager.shouldRunService() && ShizukuStateMachine.get() != ShizukuStateMachine.State.STARTING) {
 
                     // While the keyguard is up, Android tears down plain-TCP adb and kills
                     // the server. Restarting behind the lockscreen just re-kicks the same doomed

--- a/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
+++ b/manager/src/main/java/moe/shizuku/manager/settings/SettingsScreen.kt
@@ -213,7 +213,7 @@ fun SettingsScreen(
     var showUpdateSettings by remember { mutableStateOf(false) }
 
     fun tcpModeNeedsRestart(enabled: Boolean): Boolean {
-        val currentPort = EnvironmentUtils.getAdbTcpPort()
+        val currentPort = EnvironmentUtils.getActiveAdbPort()
         return Shizuku.pingBinder() && currentPort > 0 && when {
             enabled -> currentPort != AdbStarter.TCP_MODE_PORT
             else -> currentPort == AdbStarter.TCP_MODE_PORT
@@ -221,7 +221,7 @@ fun SettingsScreen(
     }
 
     fun restartAdbForTcpMode() {
-        val port = EnvironmentUtils.getAdbTcpPort().takeIf { it > 0 } ?: return
+        val port = EnvironmentUtils.getActiveAdbPort().takeIf { it > 0 } ?: return
         WatchdogManager.clearUserStopRequest(context)
         activity?.startActivity(
             Intent(context, StarterActivity::class.java).apply {

--- a/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
+++ b/manager/src/main/java/moe/shizuku/manager/utils/EnvironmentUtils.kt
@@ -60,6 +60,13 @@ object EnvironmentUtils {
         return candidates.firstOrNull { isAdbPortLive(it) } ?: -1
     }
 
+    fun getActiveAdbPort(): Int {
+        return getLiveAdbTcpPort().takeIf { it > 0 }
+            ?: getAdbTcpPort().takeIf { it > 0 }
+            ?: ShizukuSettings.getLastAdbPort().takeIf { it > 0 }
+            ?: -1
+    }
+
     fun isAdbPortLive(port: Int): Boolean {
         return try {
             Socket().use { socket ->

--- a/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
+++ b/manager/src/main/java/moe/shizuku/manager/worker/AdbStartWorker.kt
@@ -323,7 +323,9 @@ class AdbStartWorker(context: Context, params: WorkerParameters) : CoroutineWork
                         }
                     }
 
-                    Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                    if (hasSecureSettingsPermission) {
+                        Settings.Global.putInt(cr, "adb_wifi_enabled", 1)
+                    }
                     val uri = Settings.Global.getUriFor("adb_wifi_enabled")
                     if (uri != null) {
                         cr.registerContentObserver(uri, false, observer)


### PR DESCRIPTION
## Description
This PR hardens Wireless ADB startup, persistent TCP 5555 mode switching, and watchdog auto-recovery across Android 7 through 17.

### Key Changes
- **Bounded Socket Timeouts (`AdbClient.kt`):** Configured a bounded 5,000ms connect timeout (`InetSocketAddress`) and 15,000ms read timeout (`soTimeout`) on plain and TLS sockets, preventing network thread hangs when endpoints stall or drop packets.
- **TLS Mode Switch Resilience (`AdbStarter.kt`):** Caught `IOException` (including `SSLException`) on `switchToTcp()` to gracefully handle adbd TLS reset upon port switch without treating it as a failure; only disables wireless debugging once server startup has succeeded.
- **Dynamic Port Resolution (`EnvironmentUtils.kt`, `SettingsScreen.kt`):** Added `getActiveAdbPort()` to resolve live TCP, configured static, and dynamic Android 11+ TLS ports. Fixes TCP 5555 switching when running from dynamic wireless ports.
- **UI-Thread Network Offload (`HomeActivity.kt`):** Converted UI-thread socket checks in `HomeScreen` to asynchronous `produceState` on `Dispatchers.IO` to prevent `NetworkOnMainThreadException` on older Android releases and UI jank; cleaned up 160+ lines of dead/orphaned binding code.
- **Watchdog Lifecycle Synchronization (`WatchdogManager.kt`, `WatchdogService.kt`):** Extended expected death suppression window to 30s to cover full connect retry cycles; auto-clears `userStopRequested` via sticky binder listener once service binder arrives; guards against restart loops while `isStarterActive` or `ShizukuStateMachine.State.STARTING`; bounded subshell fallback termination to 3s with `runInterruptible`.
- **Pre-Android 11 & TV Boot Auto-Start (`BootCompleteReceiver.kt`):** Enabled ADB boot startup on Android < 11 devices when TCP mode or Android TV is configured; scoped `WRITE_SECURE_SETTINGS` checks strictly to API >= 30; removed dead `hasLocalNetworkPermission` helper.
- **Safe Global Settings & Worker Scoping (`AdbStartWorker.kt`, `SheveryControlReceiver.kt`):** Guarded `adb_wifi_enabled` setting mutation with `hasSecureSettingsPermission` to prevent `SecurityException` crashes; scoped `AdbStartWorker.enqueue()` strictly to `LaunchMethod.ADB`.

### Testing & Verification
- Compiled and verified via GitHub Actions release workflow (`Build Android APK` passed cleanly).
- Conforms to repository architecture, Material 3 Expressive standards, and contribution guidelines.
